### PR TITLE
Add Java benchmark code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,11 @@ node_modules
 *.tokens
 src/ConstantFolding/targets/antlr4-cpp/constant-folding-benchmark
 src/mysql/targets/antlr4-cpp/mysql-benchmark
+
+# IntelliJ IDE
+.idea/
+*.iml
+
+# Java binaries 
+out/
+*.class

--- a/src/mysql/generate.sh
+++ b/src/mysql/generate.sh
@@ -1,17 +1,21 @@
+#!/usr/bin/env sh
+
 # Generates the MySQL parser + lexer files for the benchmarks.
+ANTLR_JAR="../../antlr/antlr-4.13.1-complete.jar"
+ANTLR_SNAPSHOT_JAR="../../antlr/antlr4-4.13.1-SNAPSHOT-complete.jar"
 
 # C++
-java -jar ../../antlr/antlr-4.13.1-complete.jar \
+java -jar $ANTLR_JAR \
     -Dlanguage=Cpp -o ./targets/antlr4-cpp -no-visitor -no-listener -package parsers -Xexact-output-dir -Werror \
     ./targets/antlr4-cpp/MySQLLexer.g4 ./targets/antlr4-cpp/MySQLParser.g4
 
 # WebAssembly
-java -jar ../../antlr/antlr4-4.13.1-SNAPSHOT-complete.jar \
+java -jar $ANTLR_SNAPSHOT_JAR \
     -Dlanguage=TypeScript -o ./targets/antlr4wasm -no-visitor -no-listener -package antlr4 -Xexact-output-dir -Werror \
     ./targets/antlr4wasm/MySQLLexer.g4 ./targets/antlr4wasm/MySQLParser.g4
 
 # Old TypeScript
-java -jar ../../antlr/antlr-4.13.1-complete.jar \
+java -jar $ANTLR_JAR \
     -Dlanguage=TypeScript -o ./targets/antlr4 -no-visitor -no-listener -package antlr4 -Xexact-output-dir -Werror \
     ./targets/antlr4/MySQLLexer.g4 ./targets/antlr4/MySQLParser.g4
 
@@ -24,3 +28,8 @@ antlr4ng \
 antlr4ts \
     -o ./targets/antlr4ts -no-visitor -no-listener -package antlr4 -Xexact-output-dir -Werror \
     ./targets/antlr4ts/MySQLLexer.g4 ./targets/antlr4ts/MySQLParser.g4
+
+# Java
+java -jar $ANTLR_JAR \
+    -Dlanguage=Java -o ./targets/antlr4-java/parsers -no-visitor -no-listener -package parsers -Xexact-output-dir -Werror \
+    ./targets/antlr4-java/MySQLLexer.g4 ./targets/antlr4-java/MySQLParser.g4 

--- a/src/mysql/package.json
+++ b/src/mysql/package.json
@@ -4,11 +4,13 @@
         "generate-benchmark-parsers": "./generate.sh",
         "build-cpp-wasm": "cd targets/antlr4wasm/ && ./build-release.sh",
         "build-cpp": "cd targets/antlr4-cpp/ && ./build.sh",
+        "build-java": "cd targets/antlr4-java/ && ./build.sh",
         "run-cpp-benchmark": "cd targets/antlr4-cpp/ && ./mysql-benchmark",
         "run-antlr4ng-benchmark": "node --no-warnings=ExperimentalWarning --loader ts-node/esm targets/antlr4ng/run-benchmark.ts",
         "run-antlr4-benchmark": "node --no-warnings=ExperimentalWarning --loader ts-node/esm targets/antlr4/run-benchmark.ts",
         "run-antlr4ts-benchmark": "node --no-warnings=ExperimentalWarning --loader ts-node/esm targets/antlr4ts/run-benchmark.ts",
         "run-antlr4wasm-benchmark": "node --max-old-space-size=8192 --no-warnings=ExperimentalWarning --loader ts-node/esm targets/antlr4wasm/run-benchmark.ts",
+        "run-java-benchmark": "cd targets/antlr4-java/ && ./run.sh",
         "run-all-benchmarks": "node --max-old-space-size=8192 --no-warnings=ExperimentalWarning --loader ts-node/esm run-all-benchmarks.ts"
     }
 }

--- a/src/mysql/targets/antlr4-java/MySQLLexer.g4
+++ b/src/mysql/targets/antlr4-java/MySQLLexer.g4
@@ -1,0 +1,1126 @@
+lexer grammar MySQLLexer;
+
+/*
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License, version 2.0,
+ * as published by the Free Software Foundation.
+ *
+ * This program is designed to work with certain software (including
+ * but not limited to OpenSSL) that is licensed under separate terms, as
+ * designated in a particular file or component or in included license
+ * documentation. The authors of MySQL hereby grant you an additional
+ * permission to link the program and your derivative works with the
+ * separately licensed software that they have either included with
+ * the program or referenced in the documentation.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU General Public License, version 2.0, for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/*
+ * Merged in all changes up to mysql-trunk git revision [d2c9971] (24. January 2024).
+ *
+ * MySQL grammar for ANTLR 4.5+ with language features from MySQL 8.0 and up.
+ * The server version in the generated parser can be switched at runtime, making it so possible
+ * to switch the supported feature set dynamically.
+ *
+ * The coverage of the MySQL language should be 100%, but there might still be bugs or omissions.
+ *
+ * To use this grammar you will need a few support classes (which should be close to where you found this grammar).
+ * These classes implement the target specific action code, so we don't clutter the grammar with that
+ * and make it simpler to adjust it for other targets. See the demo/test project for further details.
+ *
+ * Written by Mike Lischke. Direct all bug reports, omissions etc. to mike.lischke@oracle.com.
+ */
+
+//-------------------------------------------------------------------------------------------------
+
+// $antlr-format alignTrailingComments on, columnLimit 150, maxEmptyLinesToKeep 1, reflowComments off, useTab off
+// $antlr-format allowShortRulesOnASingleLine on, minEmptyLines 0, alignSemicolons none
+
+options {
+    superClass = MySQLBaseLexer;
+}
+
+tokens {
+    NOT2_SYMBOL,
+    CONCAT_PIPES_SYMBOL,
+
+    // Tokens assigned in NUMBER rule.
+    INT_NUMBER, // NUM in sql_yacc.yy
+    LONG_NUMBER,
+    ULONGLONG_NUMBER
+}
+
+//-------------------------------------------------------------------------------------------------
+
+@header {/*
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates.
+ * 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+import static parsers.SqlMode.*;
+}
+
+//-------------------------------------------------------------------------------------------------
+
+// Operators
+EQUAL_OPERATOR:            '='; // Also assign.
+ASSIGN_OPERATOR:           ':=';
+NULL_SAFE_EQUAL_OPERATOR:  '<=>';
+GREATER_OR_EQUAL_OPERATOR: '>=';
+GREATER_THAN_OPERATOR:     '>';
+LESS_OR_EQUAL_OPERATOR:    '<=';
+LESS_THAN_OPERATOR:        '<';
+NOT_EQUAL_OPERATOR:        '!=';
+NOT_EQUAL2_OPERATOR:       '<>' -> type(NOT_EQUAL_OPERATOR);
+
+PLUS_OPERATOR:  '+';
+MINUS_OPERATOR: '-';
+MULT_OPERATOR:  '*';
+DIV_OPERATOR:   '/';
+
+MOD_OPERATOR: '%';
+
+LOGICAL_NOT_OPERATOR: '!';
+BITWISE_NOT_OPERATOR: '~';
+
+SHIFT_LEFT_OPERATOR:  '<<';
+SHIFT_RIGHT_OPERATOR: '>>';
+
+LOGICAL_AND_OPERATOR: '&&';
+BITWISE_AND_OPERATOR: '&';
+
+BITWISE_XOR_OPERATOR: '^';
+
+LOGICAL_OR_OPERATOR:
+    '||' { setType(isSqlModeActive(PipesAsConcat) ? CONCAT_PIPES_SYMBOL : LOGICAL_OR_OPERATOR); };
+BITWISE_OR_OPERATOR: '|';
+
+DOT_SYMBOL:         '.';
+COMMA_SYMBOL:       ',';
+SEMICOLON_SYMBOL:   ';';
+COLON_SYMBOL:       ':';
+OPEN_PAR_SYMBOL:    '(';
+CLOSE_PAR_SYMBOL:   ')';
+OPEN_CURLY_SYMBOL:  '{';
+CLOSE_CURLY_SYMBOL: '}';
+UNDERLINE_SYMBOL:   '_';
+
+JSON_SEPARATOR_SYMBOL:          '->';  // MYSQL
+JSON_UNQUOTED_SEPARATOR_SYMBOL: '->>'; // MYSQL
+
+/* INSERT OTHER OPERATORS HERE */
+
+// The MySQL server parser uses custom code in its lexer to allow base alphanum chars (and ._$) as variable name.
+// For this it handles user variables in 2 different ways and we have to model this to match that behavior.
+AT_SIGN_SYMBOL: '@';
+AT_TEXT_SUFFIX: '@' SIMPLE_IDENTIFIER;
+
+AT_AT_SIGN_SYMBOL: '@@';
+
+NULL2_SYMBOL: '\\N';
+PARAM_MARKER: '?';
+
+fragment A: [aA];
+fragment B: [bB];
+fragment C: [cC];
+fragment D: [dD];
+fragment E: [eE];
+fragment F: [fF];
+fragment G: [gG];
+fragment H: [hH];
+fragment I: [iI];
+fragment J: [jJ];
+fragment K: [kK];
+fragment L: [lL];
+fragment M: [mM];
+fragment N: [nN];
+fragment O: [oO];
+fragment P: [pP];
+fragment Q: [qQ];
+fragment R: [rR];
+fragment S: [sS];
+fragment T: [tT];
+fragment U: [uU];
+fragment V: [vV];
+fragment W: [wW];
+fragment X: [xX];
+fragment Y: [yY];
+fragment Z: [zZ];
+
+fragment DIGIT:    [0-9];
+fragment DIGITS:   DIGIT+;
+fragment HEXDIGIT: [0-9a-fA-F];
+
+// Only lower case 'x' and 'b' count for hex + bin numbers. Otherwise it's an identifier.
+HEX_NUMBER: ('0x' HEXDIGIT+) | ('x\'' HEXDIGIT+ '\'');
+BIN_NUMBER: ('0b' [01]+) | ('b\'' [01]+ '\'');
+
+INT_NUMBER: DIGITS { setType(determineNumericType(getText())); };
+
+// Float types must be handled first or the DOT_IDENTIIFER rule will make them to identifiers
+// (if there is no leading digit before the dot).
+DECIMAL_NUMBER: DIGITS? DOT_SYMBOL DIGITS;
+FLOAT_NUMBER:   (DIGITS? DOT_SYMBOL)? DIGITS [eE] (MINUS_OPERATOR | PLUS_OPERATOR)? DIGITS;
+
+// Special rule that should also match all keywords if they are directly preceded by a dot.
+// Hence it's defined before all keywords.
+// Here we make use of the ability in our base lexer to emit multiple tokens with a single rule.
+DOT_IDENTIFIER:
+    DOT_SYMBOL LETTER_WHEN_UNQUOTED_NO_DIGIT LETTER_WHEN_UNQUOTED* { emitDot(); } -> type(IDENTIFIER);
+
+// $antlr-format groupedAlignments off, alignTrailers on
+
+ACCESSIBLE_SYMBOL:                  A C C E S S I B L E;
+ACCOUNT_SYMBOL:                     A C C O U N T;
+ACTION_SYMBOL:                      A C T I O N;                                        // SQL-2003-N
+ADD_SYMBOL:                         A D D;                                              // SQL-2003-R
+ADDDATE_SYMBOL:                     A D D D A T E                                       { setType(determineFunction(ADDDATE_SYMBOL)); }; // MYSQL-FUNC
+AFTER_SYMBOL:                       A F T E R;                                          // SQL-2003-N
+AGAINST_SYMBOL:                     A G A I N S T;
+AGGREGATE_SYMBOL:                   A G G R E G A T E;
+ALGORITHM_SYMBOL:                   A L G O R I T H M;
+ALL_SYMBOL:                         A L L;                                              // SQL-2003-R
+ALTER_SYMBOL:                       A L T E R;                                          // SQL-2003-R
+ALWAYS_SYMBOL:                      A L W A Y S;
+ANALYZE_SYMBOL:                     A N A L Y Z E;
+AND_SYMBOL:                         A N D;                                              // SQL-2003-R
+ANY_SYMBOL:                         A N Y;                                              // SQL-2003-R
+AS_SYMBOL:                          A S;                                                // SQL-2003-R
+ASC_SYMBOL:                         A S C;                                              // SQL-2003-N
+ASCII_SYMBOL:                       A S C I I;                                          // MYSQL-FUNC
+ASENSITIVE_SYMBOL:                  A S E N S I T I V E;                                // FUTURE-USE
+AT_SYMBOL:                          A T;
+AUTOEXTEND_SIZE_SYMBOL:             A U T O E X T E N D '_' S I Z E;
+AUTO_INCREMENT_SYMBOL:              A U T O '_' I N C R E M E N T;
+AVG_ROW_LENGTH_SYMBOL:              A V G '_' R O W '_' L E N G T H;
+AVG_SYMBOL:                         A V G;                                              // SQL-2003-N
+BACKUP_SYMBOL:                      B A C K U P;
+BEFORE_SYMBOL:                      B E F O R E;                                        // SQL-2003-N
+BEGIN_SYMBOL:                       B E G I N;                                          // SQL-2003-R
+BETWEEN_SYMBOL:                     B E T W E E N;                                      // SQL-2003-R
+BIGINT_SYMBOL:                      B I G I N T;                                        // SQL-2003-R
+BINARY_SYMBOL:                      B I N A R Y;                                        // SQL-2003-R
+BINLOG_SYMBOL:                      B I N L O G;
+BIT_AND_SYMBOL:                     B I T '_' A N D                                     { setType(determineFunction(BIT_AND_SYMBOL)); }; // MYSQL-FUNC
+BIT_OR_SYMBOL:                      B I T '_' O R                                       { setType(determineFunction(BIT_OR_SYMBOL)); }; // MYSQL-FUNC
+BIT_SYMBOL:                         B I T;                                              // MYSQL-FUNC
+BIT_XOR_SYMBOL:                     B I T '_' X O R                                     { setType(determineFunction(BIT_XOR_SYMBOL)); }; // MYSQL-FUNC
+BLOB_SYMBOL:                        B L O B;                                            // SQL-2003-R
+BLOCK_SYMBOL:                       B L O C K;
+BOOLEAN_SYMBOL:                     B O O L E A N;                                      // SQL-2003-R
+BOOL_SYMBOL:                        B O O L;
+BOTH_SYMBOL:                        B O T H;                                            // SQL-2003-R
+BTREE_SYMBOL:                       B T R E E;
+BY_SYMBOL:                          B Y;                                                // SQL-2003-R
+BYTE_SYMBOL:                        B Y T E;
+CACHE_SYMBOL:                       C A C H E;
+CALL_SYMBOL:                        C A L L;                                            // SQL-2003-R
+CASCADE_SYMBOL:                     C A S C A D E;                                      // SQL-2003-N
+CASCADED_SYMBOL:                    C A S C A D E D;                                    // SQL-2003-R
+CASE_SYMBOL:                        C A S E;                                            // SQL-2003-R
+CAST_SYMBOL:                        C A S T                                             { setType(determineFunction(CAST_SYMBOL)); }; // SQL-2003-R
+CATALOG_NAME_SYMBOL:                C A T A L O G '_' N A M E;                          // SQL-2003-N
+CHAIN_SYMBOL:                       C H A I N;                                          // SQL-2003-N
+CHANGE_SYMBOL:                      C H A N G E;
+CHANGED_SYMBOL:                     C H A N G E D;
+CHANNEL_SYMBOL:                     C H A N N E L;
+CHARSET_SYMBOL:                     C H A R S E T;
+CHARACTER_SYMBOL:                   C H A R A C T E R                                   -> type(CHAR_SYMBOL); // Synonym
+CHAR_SYMBOL:                        C H A R;                                            // SQL-2003-R
+CHECKSUM_SYMBOL:                    C H E C K S U M;
+CHECK_SYMBOL:                       C H E C K;                                          // SQL-2003-R
+CIPHER_SYMBOL:                      C I P H E R;
+CLASS_ORIGIN_SYMBOL:                C L A S S '_' O R I G I N;                          // SQL-2003-N
+CLIENT_SYMBOL:                      C L I E N T;
+CLOSE_SYMBOL:                       C L O S E;                                          // SQL-2003-R
+COALESCE_SYMBOL:                    C O A L E S C E;                                    // SQL-2003-N
+CODE_SYMBOL:                        C O D E;
+COLLATE_SYMBOL:                     C O L L A T E;                                      // SQL-2003-R
+COLLATION_SYMBOL:                   C O L L A T I O N;                                  // SQL-2003-N
+COLUMNS_SYMBOL:                     C O L U M N S;
+COLUMN_SYMBOL:                      C O L U M N;                                        // SQL-2003-R
+COLUMN_NAME_SYMBOL:                 C O L U M N '_' N A M E;                            // SQL-2003-N
+COLUMN_FORMAT_SYMBOL:               C O L U M N '_' F O R M A T;
+COMMENT_SYMBOL:                     C O M M E N T;
+COMMITTED_SYMBOL:                   C O M M I T T E D;                                  // SQL-2003-N
+COMMIT_SYMBOL:                      C O M M I T;                                        // SQL-2003-R
+COMPACT_SYMBOL:                     C O M P A C T;
+COMPLETION_SYMBOL:                  C O M P L E T I O N;
+COMPRESSED_SYMBOL:                  C O M P R E S S E D;
+COMPRESSION_SYMBOL:                 C O M P R E S S I O N;
+CONCURRENT_SYMBOL:                  C O N C U R R E N T;
+CONDITION_SYMBOL:                   C O N D I T I O N;                                  // SQL-2003-R, SQL-2008-R
+CONNECTION_SYMBOL:                  C O N N E C T I O N;
+CONSISTENT_SYMBOL:                  C O N S I S T E N T;
+CONSTRAINT_SYMBOL:                  C O N S T R A I N T;                                // SQL-2003-R
+CONSTRAINT_CATALOG_SYMBOL:          C O N S T R A I N T '_' C A T A L O G;              // SQL-2003-N
+CONSTRAINT_NAME_SYMBOL:             C O N S T R A I N T '_' N A M E;                    // SQL-2003-N
+CONSTRAINT_SCHEMA_SYMBOL:           C O N S T R A I N T '_' S C H E M A;                // SQL-2003-N
+CONTAINS_SYMBOL:                    C O N T A I N S;                                    // SQL-2003-N
+CONTEXT_SYMBOL:                     C O N T E X T;
+CONTINUE_SYMBOL:                    C O N T I N U E;                                    // SQL-2003-R
+CONVERT_SYMBOL:                     C O N V E R T;                                      // SQL-2003-N
+COUNT_SYMBOL:                       C O U N T                                           { setType(determineFunction(COUNT_SYMBOL)); }; // SQL-2003-N
+CPU_SYMBOL:                         C P U;
+CREATE_SYMBOL:                      C R E A T E;                                        // SQL-2003-R
+CROSS_SYMBOL:                       C R O S S;                                          // SQL-2003-R
+CUBE_SYMBOL:                        C U B E;                                            // SQL-2003-R
+CURDATE_SYMBOL:                     C U R D A T E                                       { setType(determineFunction(CURDATE_SYMBOL)); }; // MYSQL-FUNC
+CURRENT_SYMBOL:                     C U R R E N T;
+CURRENT_DATE_SYMBOL:
+    C U R R E N T '_' D A T E                                                           { setType(determineFunction(CURDATE_SYMBOL)); }; // Synonym, MYSQL-FUNC
+CURRENT_TIME_SYMBOL:
+    C U R R E N T '_' T I M E                                                           { setType(determineFunction(CURTIME_SYMBOL)); }; // Synonym, MYSQL-FUNC
+CURRENT_TIMESTAMP_SYMBOL:           C U R R E N T '_' T I M E S T A M P                 -> type(NOW_SYMBOL); // Synonym
+CURRENT_USER_SYMBOL:                C U R R E N T '_' U S E R;                          // SQL-2003-R
+CURSOR_SYMBOL:                      C U R S O R;                                        // SQL-2003-R
+CURSOR_NAME_SYMBOL:                 C U R S O R '_' N A M E;                            // SQL-2003-N
+CURTIME_SYMBOL:                     C U R T I M E                                       { setType(determineFunction(CURTIME_SYMBOL)); }; // MYSQL-FUNC
+DATABASE_SYMBOL:                    D A T A B A S E;
+DATABASES_SYMBOL:                   D A T A B A S E S;
+DATAFILE_SYMBOL:                    D A T A F I L E;
+DATA_SYMBOL:                        D A T A;                                            // SQL-2003-N
+DATETIME_SYMBOL:                    D A T E T I M E;                                    // MYSQL
+DATE_ADD_SYMBOL:                    D A T E '_' A D D                                   { setType(determineFunction(DATE_ADD_SYMBOL)); };
+DATE_SUB_SYMBOL:                    D A T E '_' S U B                                   { setType(determineFunction(DATE_SUB_SYMBOL)); };
+DATE_SYMBOL:                        D A T E;                                            // SQL-2003-R
+DAYOFMONTH_SYMBOL:                  D A Y O F M O N T H                                 -> type(DAY_SYMBOL); // Synonym
+DAY_HOUR_SYMBOL:                    D A Y '_' H O U R;
+DAY_MICROSECOND_SYMBOL:             D A Y '_' M I C R O S E C O N D;
+DAY_MINUTE_SYMBOL:                  D A Y '_' M I N U T E;
+DAY_SECOND_SYMBOL:                  D A Y '_' S E C O N D;
+DAY_SYMBOL:                         D A Y;                                              // SQL-2003-R
+DEALLOCATE_SYMBOL:                  D E A L L O C A T E;                                // SQL-2003-R
+DEC_SYMBOL:                         D E C                                               -> type(DECIMAL_SYMBOL); // Synonym
+DECIMAL_SYMBOL:                     D E C I M A L;                                      // SQL-2003-R
+DECLARE_SYMBOL:                     D E C L A R E;                                      // SQL-2003-R
+DEFAULT_SYMBOL:                     D E F A U L T;                                      // SQL-2003-R
+DEFAULT_AUTH_SYMBOL:                D E F A U L T '_' A U T H;                          // Internal
+DEFINER_SYMBOL:                     D E F I N E R;
+DELAYED_SYMBOL:                     D E L A Y E D;
+DELAY_KEY_WRITE_SYMBOL:             D E L A Y '_' K E Y '_' W R I T E;
+DELETE_SYMBOL:                      D E L E T E;                                        // SQL-2003-R
+DESC_SYMBOL:                        D E S C;                                            // SQL-2003-N
+DESCRIBE_SYMBOL:                    D E S C R I B E;                                    // SQL-2003-R
+DETERMINISTIC_SYMBOL:               D E T E R M I N I S T I C;                          // SQL-2003-R
+DIAGNOSTICS_SYMBOL:                 D I A G N O S T I C S;
+DIRECTORY_SYMBOL:                   D I R E C T O R Y;
+DISABLE_SYMBOL:                     D I S A B L E;
+DISCARD_SYMBOL:                     D I S C A R D;
+DISK_SYMBOL:                        D I S K;
+DISTINCT_SYMBOL:                    D I S T I N C T;                                    // SQL-2003-R
+DISTINCTROW_SYMBOL:                 D I S T I N C T R O W                               -> type(DISTINCT_SYMBOL); // Synonym
+DIV_SYMBOL:                         D I V;
+DOUBLE_SYMBOL:                      D O U B L E;                                        // SQL-2003-R
+DO_SYMBOL:                          D O;
+DROP_SYMBOL:                        D R O P;                                            // SQL-2003-R
+DUAL_SYMBOL:                        D U A L;
+DUMPFILE_SYMBOL:                    D U M P F I L E;
+DUPLICATE_SYMBOL:                   D U P L I C A T E;
+DYNAMIC_SYMBOL:                     D Y N A M I C;                                      // SQL-2003-R
+EACH_SYMBOL:                        E A C H;                                            // SQL-2003-R
+ELSE_SYMBOL:                        E L S E;                                            // SQL-2003-R
+ELSEIF_SYMBOL:                      E L S E I F;
+ENABLE_SYMBOL:                      E N A B L E;
+ENCLOSED_SYMBOL:                    E N C L O S E D;
+ENCRYPTION_SYMBOL:                  E N C R Y P T I O N;
+END_SYMBOL:                         E N D;                                              // SQL-2003-R
+ENDS_SYMBOL:                        E N D S;
+ENGINES_SYMBOL:                     E N G I N E S;
+ENGINE_SYMBOL:                      E N G I N E;
+ENUM_SYMBOL:                        E N U M;                                            // MYSQL
+ERROR_SYMBOL:                       E R R O R;
+ERRORS_SYMBOL:                      E R R O R S;
+ESCAPED_SYMBOL:                     E S C A P E D;
+ESCAPE_SYMBOL:                      E S C A P E;                                        // SQL-2003-R
+EVENTS_SYMBOL:                      E V E N T S;
+EVENT_SYMBOL:                       E V E N T;
+EVERY_SYMBOL:                       E V E R Y;                                          // SQL-2003-N
+EXCHANGE_SYMBOL:                    E X C H A N G E;
+EXECUTE_SYMBOL:                     E X E C U T E;                                      // SQL-2003-R
+EXISTS_SYMBOL:                      E X I S T S;                                        // SQL-2003-R
+EXIT_SYMBOL:                        E X I T;
+EXPANSION_SYMBOL:                   E X P A N S I O N;
+EXPIRE_SYMBOL:                      E X P I R E;
+EXPLAIN_SYMBOL:                     E X P L A I N;                                      // SQL-2003-R
+EXPORT_SYMBOL:                      E X P O R T;
+EXTENDED_SYMBOL:                    E X T E N D E D;
+EXTENT_SIZE_SYMBOL:                 E X T E N T '_' S I Z E;
+EXTRACT_SYMBOL:                     E X T R A C T                                       { setType(determineFunction(EXTRACT_SYMBOL)); }; // SQL-2003-N
+FALSE_SYMBOL:                       F A L S E;                                          // SQL-2003-R
+FAST_SYMBOL:                        F A S T;
+FAULTS_SYMBOL:                      F A U L T S;
+FETCH_SYMBOL:                       F E T C H;                                          // SQL-2003-R
+FIELDS_SYMBOL:                      F I E L D S                                         -> type(COLUMNS_SYMBOL); // Synonym
+FILE_SYMBOL:                        F I L E;
+FILE_BLOCK_SIZE_SYMBOL:             F I L E '_' B L O C K '_' S I Z E;
+FILTER_SYMBOL:                      F I L T E R;
+FIRST_SYMBOL:                       F I R S T;                                          // SQL-2003-N
+FIXED_SYMBOL:                       F I X E D;
+FLOAT4_SYMBOL:                      F L O A T '4'                                       -> type(FLOAT_SYMBOL); // Synonym
+FLOAT8_SYMBOL:                      F L O A T '8'                                       -> type(DOUBLE_SYMBOL); // Synonym
+FLOAT_SYMBOL:                       F L O A T;                                          // SQL-2003-R
+FLUSH_SYMBOL:                       F L U S H;
+FOLLOWS_SYMBOL:                     F O L L O W S;
+FORCE_SYMBOL:                       F O R C E;
+FOREIGN_SYMBOL:                     F O R E I G N;                                      // SQL-2003-R
+FOR_SYMBOL:                         F O R;                                              // SQL-2003-R
+FORMAT_SYMBOL:                      F O R M A T;
+FOUND_SYMBOL:                       F O U N D;                                          // SQL-2003-R
+FROM_SYMBOL:                        F R O M;
+FULL_SYMBOL:                        F U L L;                                            // SQL-2003-R
+FULLTEXT_SYMBOL:                    F U L L T E X T;
+FUNCTION_SYMBOL:                    F U N C T I O N;                                    // SQL-2003-R
+GET_SYMBOL:                         G E T;
+GENERAL_SYMBOL:                     G E N E R A L;
+GENERATED_SYMBOL:                   G E N E R A T E D;
+GROUP_REPLICATION_SYMBOL:           G R O U P '_' R E P L I C A T I O N;
+GEOMETRYCOLLECTION_SYMBOL:          G E O M E T R Y C O L L E C T I O N;                // MYSQL
+GEOMETRY_SYMBOL:                    G E O M E T R Y;
+GET_FORMAT_SYMBOL:                  G E T '_' F O R M A T;                              // MYSQL-FUNC
+GLOBAL_SYMBOL:                      G L O B A L;                                        // SQL-2003-R
+GRANT_SYMBOL:                       G R A N T;                                          // SQL-2003-R
+GRANTS_SYMBOL:                      G R A N T S;
+GROUP_SYMBOL:                       G R O U P;                                          // SQL-2003-R
+GROUP_CONCAT_SYMBOL:
+    G R O U P '_' C O N C A T                                                           { setType(determineFunction(GROUP_CONCAT_SYMBOL)); };
+HANDLER_SYMBOL:                     H A N D L E R;
+HASH_SYMBOL:                        H A S H;
+HAVING_SYMBOL:                      H A V I N G;                                        // SQL-2003-R
+HELP_SYMBOL:                        H E L P;
+HIGH_PRIORITY_SYMBOL:               H I G H '_' P R I O R I T Y;
+HOST_SYMBOL:                        H O S T;
+HOSTS_SYMBOL:                       H O S T S;
+HOUR_MICROSECOND_SYMBOL:            H O U R '_' M I C R O S E C O N D;
+HOUR_MINUTE_SYMBOL:                 H O U R '_' M I N U T E;
+HOUR_SECOND_SYMBOL:                 H O U R '_' S E C O N D;
+HOUR_SYMBOL:                        H O U R;                                            // SQL-2003-R
+IDENTIFIED_SYMBOL:                  I D E N T I F I E D;
+IF_SYMBOL:                          I F;
+IGNORE_SYMBOL:                      I G N O R E;
+IGNORE_SERVER_IDS_SYMBOL:           I G N O R E '_' S E R V E R '_' I D S;
+IMPORT_SYMBOL:                      I M P O R T;
+INDEXES_SYMBOL:                     I N D E X E S;
+INDEX_SYMBOL:                       I N D E X;
+INFILE_SYMBOL:                      I N F I L E;
+INITIAL_SIZE_SYMBOL:                I N I T I A L '_' S I Z E;
+INNER_SYMBOL:                       I N N E R;                                          // SQL-2003-R
+INOUT_SYMBOL:                       I N O U T;                                          // SQL-2003-R
+INSENSITIVE_SYMBOL:                 I N S E N S I T I V E;                              // SQL-2003-R
+INSERT_SYMBOL:                      I N S E R T;                                        // SQL-2003-R
+INSERT_METHOD_SYMBOL:               I N S E R T '_' M E T H O D;
+INSTANCE_SYMBOL:                    I N S T A N C E;
+INSTALL_SYMBOL:                     I N S T A L L;
+INTEGER_SYMBOL:                     I N T E G E R                                       -> type(INT_SYMBOL); // Synonym
+INTERVAL_SYMBOL:                    I N T E R V A L;                                    // SQL-2003-R
+INTO_SYMBOL:                        I N T O;                                            // SQL-2003-R
+INT_SYMBOL:                         I N T;                                              // SQL-2003-R
+INVOKER_SYMBOL:                     I N V O K E R;
+IN_SYMBOL:                          I N;                                                // SQL-2003-R
+IO_AFTER_GTIDS_SYMBOL:              I O '_' A F T E R '_' G T I D S;                    // MYSQL, FUTURE-USE
+IO_BEFORE_GTIDS_SYMBOL:             I O '_' B E F O R E '_' G T I D S;                  // MYSQL, FUTURE-USE
+IO_THREAD_SYMBOL:                   I O '_' T H R E A D                                 -> type(RELAY_THREAD_SYMBOL); // Synonym
+IO_SYMBOL:                          I O;
+IPC_SYMBOL:                         I P C;
+IS_SYMBOL:                          I S;                                                // SQL-2003-R
+ISOLATION_SYMBOL:                   I S O L A T I O N;                                  // SQL-2003-R
+ISSUER_SYMBOL:                      I S S U E R;
+ITERATE_SYMBOL:                     I T E R A T E;
+JOIN_SYMBOL:                        J O I N;                                            // SQL-2003-R
+JSON_SYMBOL:                        J S O N;                                            // MYSQL
+KEYS_SYMBOL:                        K E Y S;
+KEY_BLOCK_SIZE_SYMBOL:              K E Y '_' B L O C K '_' S I Z E;
+KEY_SYMBOL:                         K E Y;                                              // SQL-2003-N
+KILL_SYMBOL:                        K I L L;
+LANGUAGE_SYMBOL:                    L A N G U A G E;                                    // SQL-2003-R
+LAST_SYMBOL:                        L A S T;                                            // SQL-2003-N
+LEADING_SYMBOL:                     L E A D I N G;                                      // SQL-2003-R
+LEAVES_SYMBOL:                      L E A V E S;
+LEAVE_SYMBOL:                       L E A V E;
+LEFT_SYMBOL:                        L E F T;                                            // SQL-2003-R
+LESS_SYMBOL:                        L E S S;
+LEVEL_SYMBOL:                       L E V E L;
+LIKE_SYMBOL:                        L I K E;                                            // SQL-2003-R
+LIMIT_SYMBOL:                       L I M I T;
+LINEAR_SYMBOL:                      L I N E A R;
+LINES_SYMBOL:                       L I N E S;
+LINESTRING_SYMBOL:                  L I N E S T R I N G;                                // MYSQL
+LIST_SYMBOL:                        L I S T;
+LOAD_SYMBOL:                        L O A D;
+LOCALTIME_SYMBOL:                   L O C A L T I M E                                   -> type(NOW_SYMBOL); // Synonym
+LOCALTIMESTAMP_SYMBOL:              L O C A L T I M E S T A M P                         -> type(NOW_SYMBOL); // Synonym
+LOCAL_SYMBOL:                       L O C A L;                                          // SQL-2003-R
+LOCKS_SYMBOL:                       L O C K S;
+LOCK_SYMBOL:                        L O C K;
+LOGFILE_SYMBOL:                     L O G F I L E;
+LOGS_SYMBOL:                        L O G S;
+LONGBLOB_SYMBOL:                    L O N G B L O B;                                    // MYSQL
+LONGTEXT_SYMBOL:                    L O N G T E X T;                                    // MYSQL
+LONG_SYMBOL:                        L O N G;
+LOOP_SYMBOL:                        L O O P;
+LOW_PRIORITY_SYMBOL:                L O W '_' P R I O R I T Y;
+MASTER_AUTO_POSITION_SYMBOL:        M A S T E R '_' A U T O '_' P O S I T I O N         {serverVersion < 80024}?;
+MASTER_BIND_SYMBOL:                 M A S T E R '_' B I N D                             {serverVersion < 80024}?;
+MASTER_CONNECT_RETRY_SYMBOL:        M A S T E R '_' C O N N E C T '_' R E T R Y         {serverVersion < 80024}?;
+MASTER_DELAY_SYMBOL:                M A S T E R '_' D E L A Y                           {serverVersion < 80024}?;
+MASTER_HOST_SYMBOL:                 M A S T E R '_' H O S T                             {serverVersion < 80024}?;
+MASTER_LOG_FILE_SYMBOL:             M A S T E R '_' L O G '_' F I L E                   {serverVersion < 80024}?;
+MASTER_LOG_POS_SYMBOL:              M A S T E R '_' L O G '_' P O S                     {serverVersion < 80024}?;
+MASTER_PASSWORD_SYMBOL:             M A S T E R '_' P A S S W O R D                     {serverVersion < 80024}?;
+MASTER_PORT_SYMBOL:                 M A S T E R '_' P O R T                             {serverVersion < 80024}?;
+MASTER_RETRY_COUNT_SYMBOL:          M A S T E R '_' R E T R Y '_' C O U N T             {serverVersion < 80024}?;
+MASTER_SSL_CAPATH_SYMBOL:           M A S T E R '_' S S L '_' C A P A T H               {serverVersion < 80024}?;
+MASTER_SSL_CA_SYMBOL:               M A S T E R '_' S S L '_' C A                       {serverVersion < 80024}?;
+MASTER_SSL_CERT_SYMBOL:             M A S T E R '_' S S L '_' C E R T                   {serverVersion < 80024}?;
+MASTER_SSL_CIPHER_SYMBOL:           M A S T E R '_' S S L '_' C I P H E R               {serverVersion < 80024}?;
+MASTER_SSL_CRL_SYMBOL:              M A S T E R '_' S S L '_' C R L                     {serverVersion < 80024}?;
+MASTER_SSL_CRLPATH_SYMBOL:          M A S T E R '_' S S L '_' C R L P A T H             {serverVersion < 80024}?;
+MASTER_SSL_KEY_SYMBOL:              M A S T E R '_' S S L '_' K E Y                     {serverVersion < 80024}?;
+MASTER_SSL_SYMBOL:                  M A S T E R '_' S S L                               {serverVersion < 80024}?;
+MASTER_SSL_VERIFY_SERVER_CERT_SYMBOL:
+    M A S T E R '_' S S L '_' V E R I F Y '_' S E R V E R '_' C E R T                   {serverVersion < 80024}?;
+MASTER_SYMBOL:                      M A S T E R                                         {serverVersion < 80024}?;
+MASTER_TLS_VERSION_SYMBOL:          M A S T E R '_' T L S '_' V E R S I O N             {serverVersion < 80024}?;
+MASTER_USER_SYMBOL:                 M A S T E R '_' U S E R                             {serverVersion < 80024}?;
+MASTER_HEARTBEAT_PERIOD_SYMBOL:
+    M A S T E R '_' H E A R T B E A T '_' P E R I O D                                   {serverVersion < 80024}?;
+MATCH_SYMBOL:                       M A T C H;                                          // SQL-2003-R
+MAX_CONNECTIONS_PER_HOUR_SYMBOL:    M A X '_' C O N N E C T I O N S '_' P E R '_' H O U R;
+MAX_QUERIES_PER_HOUR_SYMBOL:        M A X '_' Q U E R I E S '_' P E R '_' H O U R;
+MAX_ROWS_SYMBOL:                    M A X '_' R O W S;
+MAX_SIZE_SYMBOL:                    M A X '_' S I Z E;
+MAX_SYMBOL:                         M A X                                               { setType(determineFunction(MAX_SYMBOL)); }; // SQL-2003-N
+MAX_UPDATES_PER_HOUR_SYMBOL:        M A X '_' U P D A T E S '_' P E R '_' H O U R;
+MAX_USER_CONNECTIONS_SYMBOL:        M A X '_' U S E R '_' C O N N E C T I O N S;
+MAXVALUE_SYMBOL:                    M A X V A L U E;                                    // SQL-2003-N
+MEDIUMBLOB_SYMBOL:                  M E D I U M B L O B;                                // MYSQL
+MEDIUMINT_SYMBOL:                   M E D I U M I N T;                                  // MYSQL
+MEDIUMTEXT_SYMBOL:                  M E D I U M T E X T;                                // MYSQL
+MEDIUM_SYMBOL:                      M E D I U M;
+MEMORY_SYMBOL:                      M E M O R Y;
+MERGE_SYMBOL:                       M E R G E;                                          // SQL-2003-R
+MESSAGE_TEXT_SYMBOL:                M E S S A G E '_' T E X T;                          // SQL-2003-N
+MICROSECOND_SYMBOL:                 M I C R O S E C O N D;                              // MYSQL-FUNC
+MID_SYMBOL:                         M I D                                               { setType(determineFunction(SUBSTRING_SYMBOL)); }; // Synonym
+MIDDLEINT_SYMBOL:                   M I D D L E I N T                                   -> type(MEDIUMINT_SYMBOL); // Synonym (for Powerbuilder)
+MIGRATE_SYMBOL:                     M I G R A T E;
+MINUTE_MICROSECOND_SYMBOL:          M I N U T E '_' M I C R O S E C O N D;
+MINUTE_SECOND_SYMBOL:               M I N U T E '_' S E C O N D;
+MINUTE_SYMBOL:                      M I N U T E;                                        // SQL-2003-R
+MIN_ROWS_SYMBOL:                    M I N '_' R O W S;
+MIN_SYMBOL:                         M I N                                               { setType(determineFunction(MIN_SYMBOL)); }; // SQL-2003-N
+MODE_SYMBOL:                        M O D E;
+MODIFIES_SYMBOL:                    M O D I F I E S;                                    // SQL-2003-R
+MODIFY_SYMBOL:                      M O D I F Y;
+MOD_SYMBOL:                         M O D;                                              // SQL-2003-N
+MONTH_SYMBOL:                       M O N T H;                                          // SQL-2003-R
+MULTILINESTRING_SYMBOL:             M U L T I L I N E S T R I N G;                      // MYSQL
+MULTIPOINT_SYMBOL:                  M U L T I P O I N T;                                // MYSQL
+MULTIPOLYGON_SYMBOL:                M U L T I P O L Y G O N;                            // MYSQL
+MUTEX_SYMBOL:                       M U T E X;
+MYSQL_ERRNO_SYMBOL:                 M Y S Q L '_' E R R N O;
+NAMES_SYMBOL:                       N A M E S;                                          // SQL-2003-N
+NAME_SYMBOL:                        N A M E;                                            // SQL-2003-N
+NATIONAL_SYMBOL:                    N A T I O N A L;                                    // SQL-2003-R
+NATURAL_SYMBOL:                     N A T U R A L;                                      // SQL-2003-R
+NCHAR_SYMBOL:                       N C H A R;                                          // SQL-2003-R
+NDB_SYMBOL:                         N D B                                               -> type(NDBCLUSTER_SYMBOL); //Synonym
+NDBCLUSTER_SYMBOL:                  N D B C L U S T E R;
+NEVER_SYMBOL:                       N E V E R;
+NEW_SYMBOL:                         N E W;                                              // SQL-2003-R
+NEXT_SYMBOL:                        N E X T;                                            // SQL-2003-N
+NODEGROUP_SYMBOL:                   N O D E G R O U P;
+NONE_SYMBOL:                        N O N E;                                            // SQL-2003-R
+NOT_SYMBOL:
+    N O T                                                                               { setType(isSqlModeActive(HighNotPrecedence) ? NOT2_SYMBOL: NOT_SYMBOL); }; // SQL-2003-R
+NOW_SYMBOL:                         N O W                                               { setType(determineFunction(NOW_SYMBOL)); };
+NO_SYMBOL:                          N O;                                                // SQL-2003-R
+NO_WAIT_SYMBOL:                     N O '_' W A I T;
+NO_WRITE_TO_BINLOG_SYMBOL:          N O '_' W R I T E '_' T O '_' B I N L O G;
+NULL_SYMBOL:                        N U L L;                                            // SQL-2003-R
+NUMBER_SYMBOL:                      N U M B E R;
+NUMERIC_SYMBOL:                     N U M E R I C;                                      // SQL-2003-R
+NVARCHAR_SYMBOL:                    N V A R C H A R;
+OFFLINE_SYMBOL:                     O F F L I N E;
+OFFSET_SYMBOL:                      O F F S E T;
+ON_SYMBOL:                          O N;                                                // SQL-2003-R
+ONE_SYMBOL:                         O N E;
+ONLINE_SYMBOL:                      O N L I N E;
+ONLY_SYMBOL:                        O N L Y;
+OPEN_SYMBOL:                        O P E N;                                            // SQL-2003-R
+OPTIMIZE_SYMBOL:                    O P T I M I Z E;
+OPTIMIZER_COSTS_SYMBOL:             O P T I M I Z E R '_' C O S T S;
+OPTIONS_SYMBOL:                     O P T I O N S;
+OPTION_SYMBOL:                      O P T I O N;                                        // SQL-2003-N
+OPTIONALLY_SYMBOL:                  O P T I O N A L L Y;
+ORDER_SYMBOL:                       O R D E R;                                          // SQL-2003-R
+OR_SYMBOL:                          O R;                                                // SQL-2003-R
+OUTER_SYMBOL:                       O U T E R;
+OUTFILE_SYMBOL:                     O U T F I L E;
+OUT_SYMBOL:                         O U T;                                              // SQL-2003-R
+OWNER_SYMBOL:                       O W N E R;
+PACK_KEYS_SYMBOL:                   P A C K '_' K E Y S;
+PAGE_SYMBOL:                        P A G E;
+PARSER_SYMBOL:                      P A R S E R;
+PARTIAL_SYMBOL:                     P A R T I A L;                                      // SQL-2003-N
+PARTITIONING_SYMBOL:                P A R T I T I O N I N G;
+PARTITIONS_SYMBOL:                  P A R T I T I O N S;
+PARTITION_SYMBOL:                   P A R T I T I O N;                                  // SQL-2003-R
+PASSWORD_SYMBOL:                    P A S S W O R D;
+PHASE_SYMBOL:                       P H A S E;
+PLUGINS_SYMBOL:                     P L U G I N S;
+PLUGIN_DIR_SYMBOL:                  P L U G I N '_' D I R;                              // Internal
+PLUGIN_SYMBOL:                      P L U G I N;
+POINT_SYMBOL:                       P O I N T;
+POLYGON_SYMBOL:                     P O L Y G O N;                                      // MYSQL
+PORT_SYMBOL:                        P O R T;
+POSITION_SYMBOL:                    P O S I T I O N                                     { setType(determineFunction(POSITION_SYMBOL)); }; // SQL-2003-N
+PRECEDES_SYMBOL:                    P R E C E D E S;
+PRECISION_SYMBOL:                   P R E C I S I O N;                                  // SQL-2003-R
+PREPARE_SYMBOL:                     P R E P A R E;                                      // SQL-2003-R
+PRESERVE_SYMBOL:                    P R E S E R V E;
+PREV_SYMBOL:                        P R E V;
+PRIMARY_SYMBOL:                     P R I M A R Y;                                      // SQL-2003-R
+PRIVILEGES_SYMBOL:                  P R I V I L E G E S;                                // SQL-2003-N
+PROCEDURE_SYMBOL:                   P R O C E D U R E;                                  // SQL-2003-R
+PROCESS_SYMBOL:                     P R O C E S S;
+PROCESSLIST_SYMBOL:                 P R O C E S S L I S T;
+PROFILE_SYMBOL:                     P R O F I L E;
+PROFILES_SYMBOL:                    P R O F I L E S;
+PROXY_SYMBOL:                       P R O X Y;
+PURGE_SYMBOL:                       P U R G E;
+QUARTER_SYMBOL:                     Q U A R T E R;
+QUERY_SYMBOL:                       Q U E R Y;
+QUICK_SYMBOL:                       Q U I C K;
+RANGE_SYMBOL:                       R A N G E;                                          // SQL-2003-R
+READS_SYMBOL:                       R E A D S;                                          // SQL-2003-R
+READ_ONLY_SYMBOL:                   R E A D '_' O N L Y;
+READ_SYMBOL:                        R E A D;                                            // SQL-2003-N
+READ_WRITE_SYMBOL:                  R E A D '_' W R I T E;
+REAL_SYMBOL:                        R E A L;                                            // SQL-2003-R
+REBUILD_SYMBOL:                     R E B U I L D;
+RECOVER_SYMBOL:                     R E C O V E R;
+REDO_BUFFER_SIZE_SYMBOL:            R E D O '_' B U F F E R '_' S I Z E;
+REDUNDANT_SYMBOL:                   R E D U N D A N T;
+REFERENCES_SYMBOL:                  R E F E R E N C E S;                                // SQL-2003-R
+REGEXP_SYMBOL:                      R E G E X P;
+RELAY_SYMBOL:                       R E L A Y;
+RELAYLOG_SYMBOL:                    R E L A Y L O G;
+RELAY_LOG_FILE_SYMBOL:              R E L A Y '_' L O G '_' F I L E;
+RELAY_LOG_POS_SYMBOL:               R E L A Y '_' L O G '_' P O S;
+RELAY_THREAD_SYMBOL:                R E L A Y '_' T H R E A D;
+RELEASE_SYMBOL:                     R E L E A S E;                                      // SQL-2003-R
+RELOAD_SYMBOL:                      R E L O A D;
+REMOVE_SYMBOL:                      R E M O V E;
+RENAME_SYMBOL:                      R E N A M E;
+REORGANIZE_SYMBOL:                  R E O R G A N I Z E;
+REPAIR_SYMBOL:                      R E P A I R;
+REPEATABLE_SYMBOL:                  R E P E A T A B L E;                                // SQL-2003-N
+REPEAT_SYMBOL:                      R E P E A T;                                        // MYSQL-FUNC
+REPLACE_SYMBOL:                     R E P L A C E;                                      // MYSQL-FUNC
+REPLICATION_SYMBOL:                 R E P L I C A T I O N;
+REPLICATE_DO_DB_SYMBOL:             R E P L I C A T E '_' D O '_' D B;
+REPLICATE_IGNORE_DB_SYMBOL:         R E P L I C A T E '_' I G N O R E '_' D B;
+REPLICATE_DO_TABLE_SYMBOL:          R E P L I C A T E '_' D O '_' T A B L E;
+REPLICATE_IGNORE_TABLE_SYMBOL:      R E P L I C A T E '_' I G N O R E '_' T A B L E?;
+REPLICATE_WILD_DO_TABLE_SYMBOL:     R E P L I C A T E '_' W I L D '_' D O '_' T A B L E?;
+REPLICATE_WILD_IGNORE_TABLE_SYMBOL: R E P L I C A T E '_' W I L D '_' I G N O R E '_' T A B L E?;
+REPLICATE_REWRITE_DB_SYMBOL:        R E P L I C A T E '_' R E W R I T E '_' D B?;
+REQUIRE_SYMBOL:                     R E Q U I R E;
+RESET_SYMBOL:                       R E S E T;
+RESIGNAL_SYMBOL:                    R E S I G N A L;                                    // SQL-2003-R
+RESTORE_SYMBOL:                     R E S T O R E;
+RESTRICT_SYMBOL:                    R E S T R I C T;
+RESUME_SYMBOL:                      R E S U M E;
+RETURNED_SQLSTATE_SYMBOL:           R E T U R N E D '_' S Q L S T A T E;
+RETURNS_SYMBOL:                     R E T U R N S;                                      // SQL-2003-R
+RETURN_SYMBOL:                      R E T U R N?;                                       // SQL-2003-R
+REVERSE_SYMBOL:                     R E V E R S E;
+REVOKE_SYMBOL:                      R E V O K E;                                        // SQL-2003-R
+RIGHT_SYMBOL:                       R I G H T;                                          // SQL-2003-R
+RLIKE_SYMBOL:                       R L I K E                                           -> type(REGEXP_SYMBOL); // Synonym (like in mSQL2)
+ROLLBACK_SYMBOL:                    R O L L B A C K;                                    // SQL-2003-R
+ROLLUP_SYMBOL:                      R O L L U P;                                        // SQL-2003-R
+ROTATE_SYMBOL:                      R O T A T E;
+ROUTINE_SYMBOL:                     R O U T I N E;                                      // SQL-2003-N
+ROWS_SYMBOL:                        R O W S;                                            // SQL-2003-R
+ROW_COUNT_SYMBOL:                   R O W '_' C O U N T;
+ROW_FORMAT_SYMBOL:                  R O W '_' F O R M A T;
+ROW_SYMBOL:                         R O W;                                              // SQL-2003-R
+RTREE_SYMBOL:                       R T R E E;
+SAVEPOINT_SYMBOL:                   S A V E P O I N T;                                  // SQL-2003-R
+SCHEDULE_SYMBOL:                    S C H E D U L E;
+SCHEMA_SYMBOL:                      S C H E M A                                         -> type(DATABASE_SYMBOL); // Synonym
+SCHEMA_NAME_SYMBOL:                 S C H E M A '_' N A M E;                            // SQL-2003-N
+SCHEMAS_SYMBOL:                     S C H E M A S                                       -> type(DATABASES_SYMBOL); // Synonym
+SECOND_MICROSECOND_SYMBOL:          S E C O N D '_' M I C R O S E C O N D;
+SECOND_SYMBOL:                      S E C O N D;                                        // SQL-2003-R
+SECURITY_SYMBOL:                    S E C U R I T Y;                                    // SQL-2003-N
+SELECT_SYMBOL:                      S E L E C T;                                        // SQL-2003-R
+SENSITIVE_SYMBOL:                   S E N S I T I V E;                                  // FUTURE-USE
+SEPARATOR_SYMBOL:                   S E P A R A T O R;
+SERIALIZABLE_SYMBOL:                S E R I A L I Z A B L E;                            // SQL-2003-N
+SERIAL_SYMBOL:                      S E R I A L;
+SESSION_SYMBOL:                     S E S S I O N;                                      // SQL-2003-N
+SERVER_SYMBOL:                      S E R V E R;
+SESSION_USER_SYMBOL:
+    S E S S I O N '_' U S E R                                                           { setType(determineFunction(USER_SYMBOL)); }; // Synonym
+SET_SYMBOL:                         S E T;                                              // SQL-2003-R
+SHARE_SYMBOL:                       S H A R E;
+SHOW_SYMBOL:                        S H O W;
+SHUTDOWN_SYMBOL:                    S H U T D O W N;
+SIGNAL_SYMBOL:                      S I G N A L;                                        // SQL-2003-R
+SIGNED_SYMBOL:                      S I G N E D;
+SIMPLE_SYMBOL:                      S I M P L E;                                        // SQL-2003-N
+SLAVE_SYMBOL:                       S L A V E;
+SLOW_SYMBOL:                        S L O W;
+SMALLINT_SYMBOL:                    S M A L L I N T;                                    // SQL-2003-R
+SNAPSHOT_SYMBOL:                    S N A P S H O T;
+SOME_SYMBOL:                        S O M E                                             -> type(ANY_SYMBOL); // Synonym
+SOCKET_SYMBOL:                      S O C K E T;
+SONAME_SYMBOL:                      S O N A M E;
+SOUNDS_SYMBOL:                      S O U N D S;
+SOURCE_SYMBOL:                      S O U R C E;
+SPATIAL_SYMBOL:                     S P A T I A L;
+SPECIFIC_SYMBOL:                    S P E C I F I C;                                    // SQL-2003-R
+SQLEXCEPTION_SYMBOL:                S Q L E X C E P T I O N;                            // SQL-2003-R
+SQLSTATE_SYMBOL:                    S Q L S T A T E;                                    // SQL-2003-R
+SQLWARNING_SYMBOL:                  S Q L W A R N I N G;                                // SQL-2003-R
+SQL_AFTER_GTIDS_SYMBOL:             S Q L '_' A F T E R '_' G T I D S;                  // MYSQL
+SQL_AFTER_MTS_GAPS_SYMBOL:          S Q L '_' A F T E R '_' M T S '_' G A P S;          // MYSQL
+SQL_BEFORE_GTIDS_SYMBOL:            S Q L '_' B E F O R E '_' G T I D S;                // MYSQL
+SQL_BIG_RESULT_SYMBOL:              S Q L '_' B I G '_' R E S U L T;
+SQL_BUFFER_RESULT_SYMBOL:           S Q L '_' B U F F E R '_' R E S U L T;
+SQL_CALC_FOUND_ROWS_SYMBOL:         S Q L '_' C A L C '_' F O U N D '_' R O W S;
+SQL_NO_CACHE_SYMBOL:                S Q L '_' N O '_' C A C H E;
+SQL_SMALL_RESULT_SYMBOL:            S Q L '_' S M A L L '_' R E S U L T;
+SQL_SYMBOL:                         S Q L;                                              // SQL-2003-R
+SQL_THREAD_SYMBOL:                  S Q L '_' T H R E A D;
+SSL_SYMBOL:                         S S L;
+STACKED_SYMBOL:                     S T A C K E D;
+STARTING_SYMBOL:                    S T A R T I N G;
+STARTS_SYMBOL:                      S T A R T S;
+START_SYMBOL:                       S T A R T;                                          // SQL-2003-R
+STATS_AUTO_RECALC_SYMBOL:           S T A T S '_' A U T O '_' R E C A L C;
+STATS_PERSISTENT_SYMBOL:            S T A T S '_' P E R S I S T E N T;
+STATS_SAMPLE_PAGES_SYMBOL:          S T A T S '_' S A M P L E '_' P A G E S;
+STATUS_SYMBOL:                      S T A T U S;
+STDDEV_SAMP_SYMBOL:
+    S T D D E V '_' S A M P                                                             { setType(determineFunction(STDDEV_SAMP_SYMBOL)); }; // SQL-2003-N
+STDDEV_SYMBOL:                      S T D D E V                                         { setType(determineFunction(STD_SYMBOL)); }; // Synonym
+STDDEV_POP_SYMBOL:                  S T D D E V '_' P O P                               { setType(determineFunction(STD_SYMBOL)); }; // Synonym
+STD_SYMBOL:                         S T D                                               { setType(determineFunction(STD_SYMBOL)); };
+STOP_SYMBOL:                        S T O P;
+STORAGE_SYMBOL:                     S T O R A G E;
+STORED_SYMBOL:                      S T O R E D;
+STRAIGHT_JOIN_SYMBOL:               S T R A I G H T '_' J O I N;
+STRING_SYMBOL:                      S T R I N G;
+SUBCLASS_ORIGIN_SYMBOL:             S U B C L A S S '_' O R I G I N;                    // SQL-2003-N
+SUBDATE_SYMBOL:                     S U B D A T E                                       { setType(determineFunction(SUBDATE_SYMBOL)); };
+SUBJECT_SYMBOL:                     S U B J E C T;
+SUBPARTITIONS_SYMBOL:               S U B P A R T I T I O N S;
+SUBPARTITION_SYMBOL:                S U B P A R T I T I O N;
+SUBSTR_SYMBOL:                      S U B S T R                                         { setType(determineFunction(SUBSTRING_SYMBOL)); }; // Synonym
+SUBSTRING_SYMBOL:                   S U B S T R I N G                                   { setType(determineFunction(SUBSTRING_SYMBOL)); }; // SQL-2003-N
+SUM_SYMBOL:                         S U M                                               { setType(determineFunction(SUM_SYMBOL)); }; // SQL-2003-N
+SUPER_SYMBOL:                       S U P E R;
+SUSPEND_SYMBOL:                     S U S P E N D;
+SWAPS_SYMBOL:                       S W A P S;
+SWITCHES_SYMBOL:                    S W I T C H E S;
+SYSDATE_SYMBOL:                     S Y S D A T E                                       { setType(determineFunction(SYSDATE_SYMBOL)); };
+SYSTEM_USER_SYMBOL:                 S Y S T E M '_' U S E R                             { setType(determineFunction(USER_SYMBOL)); };
+TABLES_SYMBOL:                      T A B L E S;
+TABLESPACE_SYMBOL:                  T A B L E S P A C E;
+TABLE_SYMBOL:                       T A B L E;                                          // SQL-2003-R
+TABLE_CHECKSUM_SYMBOL:              T A B L E '_' C H E C K S U M;
+TABLE_NAME_SYMBOL:                  T A B L E '_' N A M E;                              // SQL-2003-N
+TEMPORARY_SYMBOL:                   T E M P O R A R Y;                                  // SQL-2003-N
+TEMPTABLE_SYMBOL:                   T E M P T A B L E;
+TERMINATED_SYMBOL:                  T E R M I N A T E D;
+TEXT_SYMBOL:                        T E X T;
+THAN_SYMBOL:                        T H A N;
+THEN_SYMBOL:                        T H E N;                                            // SQL-2003-R
+TIMESTAMP_SYMBOL:                   T I M E S T A M P;                                  // SQL-2003-R
+TIMESTAMPADD_SYMBOL:                T I M E S T A M P A D D;
+TIMESTAMPDIFF_SYMBOL:               T I M E S T A M P D I F F;
+TIME_SYMBOL:                        T I M E;                                            // SQL-2003-R
+TINYBLOB_SYMBOL:                    T I N Y B L O B;                                    // MYSQL
+TINYINT_SYMBOL:                     T I N Y I N T;                                      // MYSQL
+TINYTEXT_SYMBOL:                    T I N Y T E X T;                                    // MYSQL
+TO_SYMBOL:                          T O;                                                // SQL-2003-R
+TRAILING_SYMBOL:                    T R A I L I N G;                                    // SQL-2003-R
+TRANSACTION_SYMBOL:                 T R A N S A C T I O N;
+TRIGGERS_SYMBOL:                    T R I G G E R S;
+TRIGGER_SYMBOL:                     T R I G G E R;                                      // SQL-2003-R
+TRIM_SYMBOL:                        T R I M                                             { setType(determineFunction(TRIM_SYMBOL)); }; // SQL-2003-N
+TRUE_SYMBOL:                        T R U E;                                            // SQL-2003-R
+TRUNCATE_SYMBOL:                    T R U N C A T E;
+TYPES_SYMBOL:                       T Y P E S;
+TYPE_SYMBOL:                        T Y P E;                                            // SQL-2003-N
+UDF_RETURNS_SYMBOL:                 U D F '_' R E T U R N S                             {serverVersion < 80031}?;
+UNCOMMITTED_SYMBOL:                 U N C O M M I T T E D;                              // SQL-2003-N
+UNDEFINED_SYMBOL:                   U N D E F I N E D;
+UNDOFILE_SYMBOL:                    U N D O F I L E;
+UNDO_BUFFER_SIZE_SYMBOL:            U N D O '_' B U F F E R '_' S I Z E;
+UNDO_SYMBOL:                        U N D O;                                            // FUTURE-USE
+UNICODE_SYMBOL:                     U N I C O D E;
+UNINSTALL_SYMBOL:                   U N I N S T A L L;
+UNION_SYMBOL:                       U N I O N;                                          // SQL-2003-R
+UNIQUE_SYMBOL:                      U N I Q U E;
+UNKNOWN_SYMBOL:                     U N K N O W N;                                      // SQL-2003-R
+UNLOCK_SYMBOL:                      U N L O C K;
+UNSIGNED_SYMBOL:                    U N S I G N E D;                                    // MYSQL
+UNTIL_SYMBOL:                       U N T I L;
+UPDATE_SYMBOL:                      U P D A T E;                                        // SQL-2003-R
+UPGRADE_SYMBOL:                     U P G R A D E;
+USAGE_SYMBOL:                       U S A G E;                                          // SQL-2003-N
+USER_RESOURCES_SYMBOL:
+    U S E R '_' R E S O U R C E S;                                                      // Represented only as RESOURCES in server grammar.
+USER_SYMBOL:                        U S E R;                                            // SQL-2003-R
+USE_FRM_SYMBOL:                     U S E '_' F R M;
+USE_SYMBOL:                         U S E;
+USING_SYMBOL:                       U S I N G;                                          // SQL-2003-R
+UTC_DATE_SYMBOL:                    U T C '_' D A T E;
+UTC_TIMESTAMP_SYMBOL:               U T C '_' T I M E S T A M P;
+UTC_TIME_SYMBOL:                    U T C '_' T I M E;
+VALIDATION_SYMBOL:                  V A L I D A T I O N;
+VALUES_SYMBOL:                      V A L U E S;                                        // SQL-2003-R
+VALUE_SYMBOL:                       V A L U E;                                          // SQL-2003-R
+VARBINARY_SYMBOL:                   V A R B I N A R Y;                                  // SQL-2008-R
+VARCHAR_SYMBOL:                     V A R C H A R;                                      // SQL-2003-R
+VARCHARACTER_SYMBOL:                V A R C H A R A C T E R                             -> type(VARCHAR_SYMBOL); // Synonym
+VARIABLES_SYMBOL:                   V A R I A B L E S;
+VARIANCE_SYMBOL:                    V A R I A N C E                                     { setType(determineFunction(VARIANCE_SYMBOL)); };
+VARYING_SYMBOL:                     V A R Y I N G;                                      // SQL-2003-R
+VAR_POP_SYMBOL:                     V A R '_' P O P                                     { setType(determineFunction(VARIANCE_SYMBOL)); }; // Synonym
+VAR_SAMP_SYMBOL:                    V A R '_' S A M P                                   { setType(determineFunction(VAR_SAMP_SYMBOL)); };
+VIEW_SYMBOL:                        V I E W;                                            // SQL-2003-N
+VIRTUAL_SYMBOL:                     V I R T U A L;
+WAIT_SYMBOL:                        W A I T;
+WARNINGS_SYMBOL:                    W A R N I N G S;
+WEEK_SYMBOL:                        W E E K;
+WEIGHT_STRING_SYMBOL:               W E I G H T '_' S T R I N G;
+WHEN_SYMBOL:                        W H E N;                                            // SQL-2003-R
+WHERE_SYMBOL:                       W H E R E;                                          // SQL-2003-R
+WHILE_SYMBOL:                       W H I L E;
+WITH_SYMBOL:                        W I T H;                                            // SQL-2003-R
+WITHOUT_SYMBOL:                     W I T H O U T;                                      // SQL-2003-R
+WORK_SYMBOL:                        W O R K;                                            // SQL-2003-N
+WRAPPER_SYMBOL:                     W R A P P E R;
+WRITE_SYMBOL:                       W R I T E;                                          // SQL-2003-N
+X509_SYMBOL:                        X '509';
+XA_SYMBOL:                          X A;
+XID_SYMBOL:                         X I D;
+XML_SYMBOL:                         X M L;
+XOR_SYMBOL:                         X O R;
+YEAR_MONTH_SYMBOL:                  Y E A R '_' M O N T H;
+YEAR_SYMBOL:                        Y E A R;                                            // SQL-2003-R
+ZEROFILL_SYMBOL:                    Z E R O F I L L;                                    // MYSQL
+
+/*
+   Tokens from MySQL 8.0
+*/
+PERSIST_SYMBOL:                     P E R S I S T;
+ROLE_SYMBOL:                        R O L E;                                            // SQL-1999-R
+ADMIN_SYMBOL:                       A D M I N;                                          // SQL-1999-R
+INVISIBLE_SYMBOL:                   I N V I S I B L E;
+VISIBLE_SYMBOL:                     V I S I B L E;
+EXCEPT_SYMBOL:                      E X C E P T;                                        // SQL-1999-R
+COMPONENT_SYMBOL:                   C O M P O N E N T;                                  // MYSQL
+RECURSIVE_SYMBOL:                   R E C U R S I V E;                                  // SQL-1999-R
+JSON_OBJECTAGG_SYMBOL:              J S O N '_' O B J E C T A G G;                      // SQL-2015-R
+JSON_ARRAYAGG_SYMBOL:               J S O N '_' A R R A Y A G G;                        // SQL-2015-R
+OF_SYMBOL:                          O F;                                                // SQL-1999-R
+SKIP_SYMBOL:                        S K I P;                                            // MYSQL
+LOCKED_SYMBOL:                      L O C K E D;                                        // MYSQL
+NOWAIT_SYMBOL:                      N O W A I T;                                        // MYSQL
+GROUPING_SYMBOL:                    G R O U P I N G;                                    // SQL-2011-R
+PERSIST_ONLY_SYMBOL:                P E R S I S T '_' O N L Y;                          // MYSQL
+HISTOGRAM_SYMBOL:                   H I S T O G R A M;                                  // MYSQL
+BUCKETS_SYMBOL:                     B U C K E T S;                                      // MYSQL
+REMOTE_SYMBOL:                      R E M O T E                                         {serverVersion < 80014}?; // MYSQL
+CLONE_SYMBOL:                       C L O N E;                                          // MYSQL
+CUME_DIST_SYMBOL:                   C U M E '_' D I S T;                                // SQL-2003-R
+DENSE_RANK_SYMBOL:                  D E N S E '_' R A N K;                              // SQL-2003-R
+EXCLUDE_SYMBOL:                     E X C L U D E;                                      // SQL-2003-N
+FIRST_VALUE_SYMBOL:                 F I R S T '_' V A L U E;                            // SQL-2011-R
+FOLLOWING_SYMBOL:                   F O L L O W I N G;                                  // SQL-2003-N
+GROUPS_SYMBOL:                      G R O U P S;                                        // SQL-2011-R
+LAG_SYMBOL:                         L A G;                                              // SQL-2011-R
+LAST_VALUE_SYMBOL:                  L A S T '_' V A L U E;                              // SQL-2011-R
+LEAD_SYMBOL:                        L E A D;                                            // SQL-2011-R
+NTH_VALUE_SYMBOL:                   N T H '_' V A L U E;                                // SQL-2011-R
+NTILE_SYMBOL:                       N T I L E;                                          // SQL-2011-R
+NULLS_SYMBOL:                       N U L L S;                                          // SQL-2003-N
+OTHERS_SYMBOL:                      O T H E R S;                                        // SQL-2003-N
+OVER_SYMBOL:                        O V E R;                                            // SQL-2003-R
+PERCENT_RANK_SYMBOL:                P E R C E N T '_' R A N K;                          // SQL-2003-R
+PRECEDING_SYMBOL:                   P R E C E D I N G;                                  // SQL-2003-N
+RANK_SYMBOL:                        R A N K;                                            // SQL-2003-R
+RESPECT_SYMBOL:                     R E S P E C T;                                      // SQL_2011-N
+ROW_NUMBER_SYMBOL:                  R O W '_' N U M B E R;                              // SQL-2003-R
+TIES_SYMBOL:                        T I E S;                                            // SQL-2003-N
+UNBOUNDED_SYMBOL:                   U N B O U N D E D;                                  // SQL-2003-N
+WINDOW_SYMBOL:                      W I N D O W;                                        // SQL-2003-R
+EMPTY_SYMBOL:                       E M P T Y;                                          // SQL-2016-R
+JSON_TABLE_SYMBOL:                  J S O N '_' T A B L E;                              // SQL-2016-R
+NESTED_SYMBOL:                      N E S T E D;                                        // SQL-2016-N
+ORDINALITY_SYMBOL:                  O R D I N A L I T Y;                                // SQL-2003-N
+PATH_SYMBOL:                        P A T H;                                            // SQL-2003-N
+HISTORY_SYMBOL:                     H I S T O R Y;                                      // MYSQL
+REUSE_SYMBOL:                       R E U S E;                                          // MYSQL
+SRID_SYMBOL:                        S R I D;                                            // MYSQL
+THREAD_PRIORITY_SYMBOL:             T H R E A D '_' P R I O R I T Y;                    // MYSQL
+RESOURCE_SYMBOL:                    R E S O U R C E;                                    // MYSQL
+SYSTEM_SYMBOL:                      S Y S T E M;                                        // SQL-2003-R
+VCPU_SYMBOL:                        V C P U;                                            // MYSQL
+MASTER_PUBLIC_KEY_PATH_SYMBOL:      M A S T E R '_' P U B L I C '_' K E Y '_' P A T H;  // MYSQL
+GET_MASTER_PUBLIC_KEY_SYMBOL:
+    G E T '_' M A S T E R '_' P U B L I C '_' K E Y '_' S Y M                           {serverVersion < 80024}?; // MYSQL
+RESTART_SYMBOL:                     R E S T A R T                                       {serverVersion >= 80011}?; // SQL-2003-N
+DEFINITION_SYMBOL:                  D E F I N I T I O N                                 {serverVersion >= 80011}?; // MYSQL
+DESCRIPTION_SYMBOL:                 D E S C R I P T I O N                               {serverVersion >= 80011}?; // MYSQL
+ORGANIZATION_SYMBOL:                O R G A N I Z A T I O N                             {serverVersion >= 80011}?; // MYSQL
+REFERENCE_SYMBOL:                   R E F E R E N C E                                   {serverVersion >= 80011}?; // MYSQL
+
+OPTIONAL_SYMBOL:                    O P T I O N A L                                     {serverVersion >= 80013}?; // MYSQL
+SECONDARY_SYMBOL:                   S E C O N D A R Y                                   {serverVersion >= 80013}?; // MYSQL
+SECONDARY_ENGINE_SYMBOL:            S E C O N D A R Y '_' E N G I N E                   {serverVersion >= 80013}?; // MYSQL
+SECONDARY_LOAD_SYMBOL:              S E C O N D A R Y '_' L O A D                       {serverVersion >= 80013}?; // MYSQL
+SECONDARY_UNLOAD_SYMBOL:            S E C O N D A R Y '_' U N L O A D                   {serverVersion >= 80013}?; // MYSQL
+
+ACTIVE_SYMBOL:                      A C T I V E                                         {serverVersion >= 80014}?; // MYSQL
+INACTIVE_SYMBOL:                    I N A C T I V E                                     {serverVersion >= 80014}?; // MYSQL
+LATERAL_SYMBOL:                     L A T E R A L                                       {serverVersion >= 80014}?; // SQL-2003-R
+RETAIN_SYMBOL:                      R E T A I N                                         {serverVersion >= 80014}?; // MYSQL
+OLD_SYMBOL:                         O L D                                               {serverVersion >= 80014}?; // SQL-2003-R
+
+NETWORK_NAMESPACE_SYMBOL:           N E T W O R K '_' N A M E S P A C E                 {serverVersion >= 80017}?; // MYSQL
+ENFORCED_SYMBOL:                    E N F O R C E D                                     {serverVersion >= 80017}?; // SQL-2003-N
+ARRAY_SYMBOL:                       A R R A Y                                           {serverVersion >= 80017}?; // SQL-2003-R
+OJ_SYMBOL:                          O J                                                 {serverVersion >= 80017}?; // ODBC
+MEMBER_SYMBOL:                      M E M B E R                                         {serverVersion >= 80017}?; // SQL-2003-R
+
+RANDOM_SYMBOL:                      R A N D O M                                         {serverVersion >= 80018}?; // MYSQL
+MASTER_COMPRESSION_ALGORITHM_SYMBOL:
+    M A S T E R '_' C O M P R E S S I O N '_' A L G O R I T H M                         {serverVersion >= 80018 && serverVersion < 80024}?; // MYSQL
+MASTER_ZSTD_COMPRESSION_LEVEL_SYMBOL:
+    M A S T E R '_' Z S T D '_' C O M P R E S S I O N '_' L E V E L                     {serverVersion >= 80018}?; // MYSQL
+PRIVILEGE_CHECKS_USER_SYMBOL:
+    P R I V I L E G E '_' C H E C K S '_' U S E R                                       {serverVersion >= 80018}?; // MYSQL
+MASTER_TLS_CIPHERSUITES_SYMBOL:
+    M A S T E R '_' T L S '_' C I P H E R S U I T E S                                   {serverVersion >= 80018}?; // MYSQL
+
+REQUIRE_ROW_FORMAT_SYMBOL:
+    R E Q U I R E '_' R O W '_' F O R M A T                                             {serverVersion >= 80019}?; // MYSQL
+PASSWORD_LOCK_TIME_SYMBOL:
+    P A S S W O R D '_' L O C K '_' T I M E                                             {serverVersion >= 80019}?; // MYSQL
+FAILED_LOGIN_ATTEMPTS_SYMBOL:
+    F A I L E D '_' L O G I N '_' A T T E M P T S                                       {serverVersion >= 80019}?; // MYSQL
+REQUIRE_TABLE_PRIMARY_KEY_CHECK_SYMBOL:
+    R E Q U I R E '_' T A B L E '_' P R I M A R Y '_' K E Y '_' C H E C K               {serverVersion >= 80019}?; // MYSQL
+STREAM_SYMBOL:                      S T R E A M                                         {serverVersion >= 80019}?; // MYSQL
+OFF_SYMBOL:                         O F F                                               {serverVersion >= 80019}?; // SQL-1999-R
+
+RETURNING_SYMBOL:                   R E T U R N I N G                                   {serverVersion >= 80024}?; // SQL-2016-N
+JSON_VALUE_SYMBOL:                  J S O N '_' V A L U E                               {serverVersion >= 80024}?; // SQL-2016-R
+TLS_SYMBOL:                         T L S                                               {serverVersion >= 80024}?; // MYSQL
+ATTRIBUTE_SYMBOL:                   A T T R I B U T E                                   {serverVersion >= 80024}?; // SQL-2003-N
+ENGINE_ATTRIBUTE_SYMBOL:            E N G I N E '_' A T T R I B U T E                   {serverVersion >= 80024}?; // MYSQL
+SECONDARY_ENGINE_ATTRIBUTE_SYMBOL:
+    S E C O N D A R Y '_' E N G I N E '_' A T T R I B U T E                             {serverVersion >= 80024}?; // MYSQL
+SOURCE_CONNECTION_AUTO_FAILOVER_SYMBOL:
+    S O U R C E '_' C O N N E C T I O N '_' A U T O '_' F A I L O V E R                 {serverVersion >= 80024}?; // MYSQL
+ZONE_SYMBOL:                        Z O N E                                             {serverVersion >= 80024}?; // SQL-2003-N
+GRAMMAR_SELECTOR_DERIVED_EXPR:
+    G R A M M A R '_' S E L E C T O R '_' D E R I V E D                                 {serverVersion >= 80024}?; // synthetic token: starts derived table expressions.
+REPLICA_SYMBOL:                     R E P L I C A                                       {serverVersion >= 80024}?;
+REPLICAS_SYMBOL:                    R E P L I C A S                                     {serverVersion >= 80024}?;
+ASSIGN_GTIDS_TO_ANONYMOUS_TRANSACTIONS_SYMBOL:
+    A S S I G N '_' G T I D S '_' T O '_' A N O N Y M O U S '_' T R A N S A C T I O N S {serverVersion >= 80024}?; // MYSQL
+GET_SOURCE_PUBLIC_KEY_SYMBOL:
+    G E T '_' S O U R C E '_' P U B L I C '_' K E Y                                     {serverVersion >= 80024}?; // MYSQL
+SOURCE_AUTO_POSITION_SYMBOL:
+    S O U R C E '_' A U T O '_' P O S I T I O N                                         {serverVersion >= 80024}?; // MYSQL
+SOURCE_BIND_SYMBOL:                 S O U R C E '_' B I N D                             {serverVersion >= 80024}?; // MYSQL
+SOURCE_COMPRESSION_ALGORITHM_SYMBOL:
+    S O U R C E '_' C O M P R E S S I O N '_' A L G O R I T H M                         {serverVersion >= 80024}?; // MYSQL
+SOURCE_CONNECT_RETRY_SYMBOL:
+    S O U R C E '_' C O N N E C T '_' R E T R Y                                         {serverVersion >= 80024}?; // MYSQL
+SOURCE_DELAY_SYMBOL:                S O U R C E '_' D E L A Y                           {serverVersion >= 80024}?; // MYSQL
+SOURCE_HEARTBEAT_PERIOD_SYMBOL:
+    S O U R C E '_' H E A R T B E A T '_' P E R I O D                                   {serverVersion >= 80024}?; // MYSQL
+SOURCE_HOST_SYMBOL:                 S O U R C E '_' H O S T                             {serverVersion >= 80024}?; // MYSQL
+SOURCE_LOG_FILE_SYMBOL:             S O U R C E '_' L O G '_' F I L E                   {serverVersion >= 80024}?; // MYSQL
+SOURCE_LOG_POS_SYMBOL:              S O U R C E '_' L O G '_' P O S                     {serverVersion >= 80024}?; // MYSQL
+SOURCE_PASSWORD_SYMBOL:             S O U R C E '_' P A S S W O R D                     {serverVersion >= 80024}?; // MYSQL
+SOURCE_PORT_SYMBOL:                 S O U R C E '_' P O R T                             {serverVersion >= 80024}?; // MYSQL
+SOURCE_PUBLIC_KEY_PATH_SYMBOL:
+    S O U R C E '_' P U B L I C '_' K E Y '_' P A T H                                   {serverVersion >= 80024}?; // MYSQL
+SOURCE_RETRY_COUNT_SYMBOL:
+    S O U R C E '_' R E T R Y '_' C O U N T                                             {serverVersion >= 80024}?; // MYSQL
+SOURCE_SSL_SYMBOL:                  S O U R C E '_' S S L                               {serverVersion >= 80024}?; // MYSQL
+SOURCE_SSL_CA_SYMBOL:               S O U R C E '_' S S L '_' C A                       {serverVersion >= 80024}?; // MYSQL
+SOURCE_SSL_CAPATH_SYMBOL:           S O U R C E '_' S S L '_' C A P A T H               {serverVersion >= 80024}?; // MYSQL
+SOURCE_SSL_CERT_SYMBOL:             S O U R C E '_' S S L '_' C E R T                   {serverVersion >= 80024}?; // MYSQL
+SOURCE_SSL_CIPHER_SYMBOL:           S O U R C E '_' S S L '_' C I P H E R               {serverVersion >= 80024}?; // MYSQL
+SOURCE_SSL_CRL_SYMBOL:              S O U R C E '_' S S L '_' C R L                     {serverVersion >= 80024}?; // MYSQL
+SOURCE_SSL_CRLPATH_SYMBOL:
+    S O U R C E '_' S S L '_' C R L P A T H                                             {serverVersion >= 80024}?; // MYSQL
+SOURCE_SSL_KEY_SYMBOL:              S O U R C E '_' S S L '_' C R L P A T H             {serverVersion >= 80024}?; // MYSQL
+SOURCE_SSL_VERIFY_SERVER_CERT_SYMBOL:
+    S O U R C E '_' S S L '_' V E R I F Y '_' S E R V E R '_' C E R T                   {serverVersion >= 80024}?; // MYSQL
+SOURCE_TLS_CIPHERSUITES_SYMBOL:
+    S O U R C E '_' T L S '_' C I P H E R S U I T E S                                   {serverVersion >= 80024}?; // MYSQL
+SOURCE_TLS_VERSION_SYMBOL:
+    S O U R C E '_' T L S '_' V E R S I O N                                             {serverVersion >= 80024}?; // MYSQL
+SOURCE_USER_SYMBOL:                 S O U R C E '_' U S E R                             {serverVersion >= 80024}?; // MYSQL
+SOURCE_ZSTD_COMPRESSION_LEVEL_SYMBOL:
+    S O U R C E '_' Z S T D '_' C O M P R E S S I O N '_' L E V E L                     {serverVersion >= 80024}?; // MYSQL
+
+ST_COLLECT_SYMBOL:                  S T '_' C O L L E C T                               {serverVersion >= 80025}?; // MYSQL
+KEYRING_SYMBOL:                     K E Y R I N G                                       {serverVersion >= 80025}?; // MYSQL
+
+AUTHENTICATION_SYMBOL:              A U T H E N T I C A T I O N                         {serverVersion >= 80027}?; // MYSQL
+FACTOR_SYMBOL:                      F A C T O R                                         {serverVersion >= 80027}?; // MYSQL
+FINISH_SYMBOL:                      F I N I S H                                         {serverVersion >= 80027}?; // SQL-2016-N
+INITIATE_SYMBOL:                    I N I T I A T E                                     {serverVersion >= 80027}?; // MYSQL
+REGISTRATION_SYMBOL:                R E G I S T R A T I O N                             {serverVersion >= 80027}?; // MYSQL
+UNREGISTER_SYMBOL:                  U N R E G I S T E R                                 {serverVersion >= 80027}?; // MYSQL
+INITIAL_SYMBOL:                     I N I T I A L                                       {serverVersion >= 80027}?; // SQL-2016-R
+CHALLENGE_RESPONSE_SYMBOL:          C H A L L E N G E '_' R E S P O N S E               {serverVersion >= 80027}?; // MYSQL
+GTID_ONLY_SYMBOL:                   G T I D '_' O N L Y                                 {serverVersion >= 80027}?; // MYSQL
+
+INTERSECT_SYMBOL:                   I N T E R S E C T '_' S Y M B O L                   {serverVersion >= 80031}?; // SQL-1992-R
+
+BULK_SYMBOL:                        B U L K                                             {serverVersion >= 80200}?; // MYSQL
+URL_SYMBOL:                         U R L                                               {serverVersion >= 80200}?; // MYSQL
+GENERATE_SYMBOL:                    G E N E R A T E                                     {serverVersion >= 80032}?; // MYSQL
+PARSE_TREE_SYMBOL:                  P A R S E '_' T R E E                               {serverVersion >= 80100}?; // MYSQL
+LOG_SYMBOL:                         L O G                                               {serverVersion >= 80032}?; // MYSQL
+GTIDS_SYMBOL:                       G T I D S                                           {serverVersion >= 80032}?; // MYSQL
+
+PARALLEL_SYMBOL:                    P A R A L L E L                                     {serverVersion >= 80200}?; // MYSQL
+S3_SYMBOL:                          S '3'                                               {serverVersion >= 80200}?; // MYSQL
+QUALIFY_SYMBOL:                     Q U A L I F Y                                       {serverVersion >= 80200}?; // MYSQL
+AUTO_SYMBOL:                        A U T O                                             {serverVersion >= 80200}?; // MYSQL
+MANUAL_SYMBOL:                      M A N U A L                                         {serverVersion >= 80200}?; // MYSQL
+BENROULLI_SYMBOL:                   B E N R O U L L I                                   {serverVersion >= 80200}?; // MYSQL
+TABLESAMPLE_SYMBOL:                 T A B L E S A M P L E                               {serverVersion >= 80200}?; // MYSQL
+
+// $antlr-format groupedAlignments on, alignTrailers off, alignLexerCommands on
+
+// Additional tokens which are mapped to existing tokens.
+INT1_SYMBOL: I N T '1' -> type(TINYINT_SYMBOL);   // Synonym
+INT2_SYMBOL: I N T '2' -> type(SMALLINT_SYMBOL);  // Synonym
+INT3_SYMBOL: I N T '3' -> type(MEDIUMINT_SYMBOL); // Synonym
+INT4_SYMBOL: I N T '4' -> type(INT_SYMBOL);       // Synonym
+INT8_SYMBOL: I N T '8' -> type(BIGINT_SYMBOL);    // Synonym
+
+SQL_TSI_SECOND_SYMBOL:  S Q L '_' T S I '_' S E C O N D   -> type(SECOND_SYMBOL);  // Synonym
+SQL_TSI_MINUTE_SYMBOL:  S Q L '_' T S I '_' M I N U T E   -> type(MINUTE_SYMBOL);  // Synonym
+SQL_TSI_HOUR_SYMBOL:    S Q L '_' T S I '_' H O U R       -> type(HOUR_SYMBOL);    // Synonym
+SQL_TSI_DAY_SYMBOL:     S Q L '_' T S I '_' D A Y         -> type(DAY_SYMBOL);     // Synonym
+SQL_TSI_WEEK_SYMBOL:    S Q L '_' T S I '_' W E E K       -> type(WEEK_SYMBOL);    // Synonym
+SQL_TSI_MONTH_SYMBOL:   S Q L '_' T S I '_' M O N T H     -> type(MONTH_SYMBOL);   // Synonym
+SQL_TSI_QUARTER_SYMBOL: S Q L '_' T S I '_' Q U A R T E R -> type(QUARTER_SYMBOL); // Synonym
+SQL_TSI_YEAR_SYMBOL:    S Q L '_' T S I '_' Y E A R       -> type(YEAR_SYMBOL);    // Synonym
+
+/* INSERT OTHER KEYWORDS HERE */
+
+// White space handling
+WHITESPACE: [ \t\f\r\n]+ -> channel(HIDDEN); // Ignore whitespaces.
+
+// Input not covered elsewhere (unless quoted).
+INVALID_INPUT:
+    [\u0001-\u0008]   // Control codes.
+    | '\u000B'        // Line tabulation.
+    | '\u000C'        // Form feed.
+    | [\u000E-\u001F] // More control codes.
+    | '['
+    | ']';
+
+// String and text types.
+
+// The underscore charset token is used to defined the repertoire of a string, though it conflicts
+// with normal identifiers, which also can start with an underscore.
+UNDERSCORE_CHARSET: UNDERLINE_SYMBOL [a-z0-9]+ { setType(checkCharset(getText())); };
+
+// Identifiers might start with a digit, even though it is discouraged, and may not consist entirely of digits only.
+// All keywords above are automatically excluded.
+IDENTIFIER:
+    DIGITS+ [eE] (LETTER_WHEN_UNQUOTED_NO_DIGIT LETTER_WHEN_UNQUOTED*)? // Have to exclude float pattern, as this rule matches more.
+    | DIGITS+ LETTER_WITHOUT_FLOAT_PART LETTER_WHEN_UNQUOTED*
+    | LETTER_WHEN_UNQUOTED_NO_DIGIT LETTER_WHEN_UNQUOTED*; // INT_NUMBER matches first if there are only digits.
+
+NCHAR_TEXT: [nN] SINGLE_QUOTED_TEXT;
+
+// MySQL supports automatic concatenation of multiple single and double quoted strings if they follow each other as separate
+// tokens. This is reflected in the `textLiteral` parser rule.
+// Here we handle duplication of quotation chars only (which must be replaced by a single char in the target code).
+
+fragment BACK_TICK:    '`';
+fragment SINGLE_QUOTE: '\'';
+fragment DOUBLE_QUOTE: '"';
+
+BACK_TICK_QUOTED_ID: BACK_TICK (({!isSqlModeActive(NoBackslashEscapes)}? '\\')? .)*? BACK_TICK;
+
+DOUBLE_QUOTED_TEXT: (
+        DOUBLE_QUOTE (({!isSqlModeActive(NoBackslashEscapes)}? '\\')? .)*? DOUBLE_QUOTE
+    )+;
+
+SINGLE_QUOTED_TEXT: (
+        SINGLE_QUOTE (({!isSqlModeActive(NoBackslashEscapes)}? '\\')? .)*? SINGLE_QUOTE
+    )+;
+
+// TODO: check in the semantic phase that starting and ending tags are the same.
+DOLLAR_QUOTED_STRING_TEXT:
+    '$' DOLLAR_QUOTE_TAG_CHAR* '$' .*? '$' DOLLAR_QUOTE_TAG_CHAR* '$'; // {supportMle}?;
+
+// There are 3 types of block comments:
+// /* ... */ - The standard multi line comment.
+// /*! ... */ - A comment used to mask code for other clients. In MySQL the content is handled as normal code.
+// /*!12345 ... */ - Same as the previous one except code is only used when the given number is lower than or equal to
+//                   the current server version (specifying so the minimum server version the code can run with).
+VERSION_COMMENT_START: ('/*!' DIGITS) (
+        {checkMySQLVersion(getText())}? // Will set inVersionComment if the number matches.
+        | .*? '*/'
+    ) -> channel(HIDDEN);
+
+// inVersionComment is a variable in the base lexer.
+// TODO: use a lexer mode instead of a member variable.
+MYSQL_COMMENT_START: '/*!' { inVersionComment = true; }                     -> channel(HIDDEN);
+VERSION_COMMENT_END: '*/' {inVersionComment}? { inVersionComment = false; } -> channel(HIDDEN);
+BLOCK_COMMENT:       ( '/**/' | '/*' ~[!] .*? '*/')                         -> channel(HIDDEN);
+
+INVALID_BLOCK_COMMENT: '/*' ~[*/]* EOF -> channel(HIDDEN); // Not 100% perfect but good enough.
+
+POUND_COMMENT:    '#' ~([\n\r])*                                   -> channel(HIDDEN);
+DASHDASH_COMMENT: DOUBLE_DASH ([ \t] (~[\n\r])* | LINEBREAK | EOF) -> channel(HIDDEN);
+
+fragment DOUBLE_DASH: '--';
+fragment LINEBREAK:   [\n\r];
+
+fragment SIMPLE_IDENTIFIER: (DIGIT | [a-zA-Z_$] | DOT_SYMBOL)+;
+
+fragment ML_COMMENT_HEAD: '/*';
+fragment ML_COMMENT_END:  '*/';
+
+// As defined in https://dev.mysql.com/doc/refman/8.0/en/identifiers.html.
+fragment LETTER_WHEN_UNQUOTED: DIGIT | LETTER_WHEN_UNQUOTED_NO_DIGIT;
+
+fragment LETTER_WHEN_UNQUOTED_NO_DIGIT: [a-zA-Z_$\u0080-\uffff];
+fragment DOLLAR_QUOTE_TAG_CHAR:         [0-9a-zA-Z_\u0080-\uffff];
+
+// Any letter but without e/E and digits (which are used to match a decimal number).
+fragment LETTER_WITHOUT_FLOAT_PART: [a-df-zA-DF-Z_$\u0080-\uffff];

--- a/src/mysql/targets/antlr4-java/MySQLParser.g4
+++ b/src/mysql/targets/antlr4-java/MySQLParser.g4
@@ -1,0 +1,5608 @@
+parser grammar MySQLParser;
+
+/*
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License, version 2.0,
+ * as published by the Free Software Foundation.
+ *
+ * This program is designed to work with certain software (including
+ * but not limited to OpenSSL) that is licensed under separate terms, as
+ * designated in a particular file or component or in included license
+ * documentation. The authors of MySQL hereby grant you an additional
+ * permission to link the program and your derivative works with the
+ * separately licensed software that they have either included with
+ * the program or referenced in the documentation.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See
+ * the GNU General Public License, version 2.0, for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/*
+ * Merged in all changes up to mysql-trunk git revision [d2c9971] (24. January 2024).
+ *
+ * MySQL grammar for ANTLR 4.5+ with language features from MySQL 8.0 and up.
+ * The server version in the generated parser can be switched at runtime, making it so possible
+ * to switch the supported feature set dynamically.
+ *
+ * The coverage of the MySQL language should be 100%, but there might still be bugs or omissions.
+ *
+ * To use this grammar you will need a few support classes (which should be close to where you found this grammar).
+ * These classes implement the target specific action code, so we don't clutter the grammar with that
+ * and make it simpler to adjust it for other targets. See the demo/test project for further details.
+ *
+ * Written by Mike Lischke. Direct all bug reports, omissions etc. to mike.lischke@oracle.com.
+ */
+
+//----------------------------------------------------------------------------------------------------------------------
+
+// $antlr-format alignTrailingComments on, columnLimit 130, minEmptyLines 1, maxEmptyLinesToKeep 1, reflowComments off
+// $antlr-format useTab off, allowShortRulesOnASingleLine off, allowShortBlocksOnASingleLine on, alignSemicolons ownLine
+
+options {
+    superClass = MySQLBaseRecognizer;
+    tokenVocab = MySQLLexer;
+}
+
+@header {/* Copyright (c) 2020, 2024, Oracle and/or its affiliates. */
+import static parsers.SqlMode.*;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+query:
+    ((simpleStatement | beginWork) SEMICOLON_SYMBOL?)? EOF
+;
+
+simpleStatement:
+    // DDL
+    alterStatement
+    | createStatement
+    | dropStatement
+    | renameTableStatement
+    | truncateTableStatement
+    | importStatement
+
+    // DML
+    | callStatement
+    | deleteStatement
+    | doStatement
+    | handlerStatement
+    | insertStatement
+    | loadStatement
+    | replaceStatement
+    | selectStatement
+    | updateStatement
+    | transactionOrLockingStatement
+    | replicationStatement
+    | preparedStatement
+
+    // Data Directory
+    | cloneStatement
+
+    // Database administration
+    | accountManagementStatement
+    | tableAdministrationStatement
+    | uninstallStatement
+    | installStatement
+    | setStatement // SET PASSWORD is handled in accountManagementStatement.
+    | showDatabasesStatement
+    | showTablesStatement
+    | showTriggersStatement
+    | showEventsStatement
+    | showTableStatusStatement
+    | showOpenTablesStatement
+    | showParseTreeStatement
+    | showPluginsStatement
+    | showEngineLogsStatement
+    | showEngineMutexStatement
+    | showEngineStatusStatement
+    | showColumnsStatement
+    | showBinaryLogsStatement
+    | showBinaryLogStatusStatement
+    | showReplicasStatement
+    | showBinlogEventsStatement
+    | showRelaylogEventsStatement
+    | showKeysStatement
+    | showEnginesStatement
+    | showCountWarningsStatement
+    | showCountErrorsStatement
+    | showWarningsStatement
+    | showErrorsStatement
+    | showProfilesStatement
+    | showProfileStatement
+    | showStatusStatement
+    | showProcessListStatement
+    | showVariablesStatement
+    | showCharacterSetStatement
+    | showCollationStatement
+    | showPrivilegesStatement
+    | showGrantsStatement
+    | showCreateDatabaseStatement
+    | showCreateTableStatement
+    | showCreateViewStatement
+    | showMasterStatusStatement
+    | showReplicaStatusStatement
+    | showCreateProcedureStatement
+    | showCreateFunctionStatement
+    | showCreateTriggerStatement
+    | showCreateProcedureStatusStatement
+    | showCreateFunctionStatusStatement
+    | showCreateProcedureCodeStatement
+    | showCreateFunctionCodeStatement
+    | showCreateEventStatement
+    | showCreateUserStatement
+    | resourceGroupManagement
+    | otherAdministrativeStatement
+
+    // MySQL utility statements
+    | utilityStatement
+    | getDiagnosticsStatement
+    | signalStatement
+    | resignalStatement
+;
+
+//----------------- DDL statements -------------------------------------------------------------------------------------
+
+alterStatement:
+    ALTER_SYMBOL (
+        alterTable
+        | alterDatabase
+        | PROCEDURE_SYMBOL procedureRef routineAlterOptions?
+        | FUNCTION_SYMBOL functionRef routineAlterOptions?
+        | alterView
+        | alterEvent
+        | alterTablespace
+        | {serverVersion >= 80014}? alterUndoTablespace
+        | alterLogfileGroup
+        | alterServer
+        // ALTER USER is part of the user management rule.
+        | alterInstanceStatement
+    )
+;
+
+alterDatabase:
+    DATABASE_SYMBOL schemaRef alterDatabaseOption+
+;
+
+alterDatabaseOption:
+    createDatabaseOption
+    | READ_SYMBOL ONLY_SYMBOL EQUAL_OPERATOR? ternaryOption
+;
+
+alterEvent:
+    definerClause? EVENT_SYMBOL eventRef (ON_SYMBOL SCHEDULE_SYMBOL schedule)? (
+        ON_SYMBOL COMPLETION_SYMBOL NOT_SYMBOL? PRESERVE_SYMBOL
+    )? (RENAME_SYMBOL TO_SYMBOL identifier)? (
+        ENABLE_SYMBOL
+        | DISABLE_SYMBOL (ON_SYMBOL replica)?
+    )? (COMMENT_SYMBOL textLiteral)? (DO_SYMBOL compoundStatement)?
+;
+
+alterLogfileGroup:
+    LOGFILE_SYMBOL GROUP_SYMBOL logfileGroupRef ADD_SYMBOL UNDOFILE_SYMBOL textLiteral alterLogfileGroupOptions?
+;
+
+alterLogfileGroupOptions:
+    alterLogfileGroupOption (COMMA_SYMBOL? alterLogfileGroupOption)*
+;
+
+alterLogfileGroupOption:
+    tsOptionInitialSize
+    | tsOptionEngine
+    | tsOptionWait
+;
+
+alterServer:
+    SERVER_SYMBOL serverRef serverOptions
+;
+
+alterTable:
+    onlineOption? TABLE_SYMBOL tableRef alterTableActions?
+;
+
+alterTableActions:
+    alterCommandList (partitionClause | removePartitioning)?
+    | partitionClause
+    | removePartitioning
+    | (alterCommandsModifierList COMMA_SYMBOL)? standaloneAlterCommands
+;
+
+alterCommandList:
+    alterCommandsModifierList
+    | (alterCommandsModifierList COMMA_SYMBOL)? alterList
+;
+
+alterCommandsModifierList:
+    alterCommandsModifier (COMMA_SYMBOL alterCommandsModifier)*
+;
+
+standaloneAlterCommands:
+    DISCARD_SYMBOL TABLESPACE_SYMBOL
+    | IMPORT_SYMBOL TABLESPACE_SYMBOL
+    | alterPartition
+    | {serverVersion >= 80014}? (SECONDARY_LOAD_SYMBOL | SECONDARY_UNLOAD_SYMBOL)
+;
+
+alterPartition:
+    ADD_SYMBOL PARTITION_SYMBOL noWriteToBinLog? (
+        partitionDefinitions
+        | PARTITIONS_SYMBOL real_ulong_number
+    )
+    | DROP_SYMBOL PARTITION_SYMBOL identifierList
+    | REBUILD_SYMBOL PARTITION_SYMBOL noWriteToBinLog? allOrPartitionNameList
+
+    // yes, twice "no write to bin log".
+    | OPTIMIZE_SYMBOL PARTITION_SYMBOL noWriteToBinLog? allOrPartitionNameList noWriteToBinLog?
+    | ANALYZE_SYMBOL PARTITION_SYMBOL noWriteToBinLog? allOrPartitionNameList
+    | CHECK_SYMBOL PARTITION_SYMBOL allOrPartitionNameList checkOption*
+    | REPAIR_SYMBOL PARTITION_SYMBOL noWriteToBinLog? allOrPartitionNameList repairType*
+    | COALESCE_SYMBOL PARTITION_SYMBOL noWriteToBinLog? real_ulong_number
+    | TRUNCATE_SYMBOL PARTITION_SYMBOL allOrPartitionNameList
+    | REORGANIZE_SYMBOL PARTITION_SYMBOL noWriteToBinLog? (
+        identifierList INTO_SYMBOL partitionDefinitions
+    )?
+    | EXCHANGE_SYMBOL PARTITION_SYMBOL identifier WITH_SYMBOL TABLE_SYMBOL tableRef withValidation?
+    | DISCARD_SYMBOL PARTITION_SYMBOL allOrPartitionNameList TABLESPACE_SYMBOL
+    | IMPORT_SYMBOL PARTITION_SYMBOL allOrPartitionNameList TABLESPACE_SYMBOL
+;
+
+alterList:
+    (alterListItem | createTableOptionsSpaceSeparated) (
+        COMMA_SYMBOL (
+            alterListItem
+            | alterCommandsModifier
+            | createTableOptionsSpaceSeparated
+        )
+    )*
+;
+
+alterCommandsModifier:
+    alterAlgorithmOption
+    | alterLockOption
+    | withValidation
+;
+
+alterListItem:
+    ADD_SYMBOL COLUMN_SYMBOL? (
+        identifier fieldDefinition checkOrReferences? place?
+        | OPEN_PAR_SYMBOL tableElementList CLOSE_PAR_SYMBOL
+    )
+    | ADD_SYMBOL tableConstraintDef
+    | CHANGE_SYMBOL COLUMN_SYMBOL? columnInternalRef identifier fieldDefinition place?
+    | MODIFY_SYMBOL COLUMN_SYMBOL? columnInternalRef fieldDefinition place?
+    | DROP_SYMBOL (
+        COLUMN_SYMBOL? columnInternalRef restrict?
+        | FOREIGN_SYMBOL KEY_SYMBOL columnInternalRef
+        | PRIMARY_SYMBOL KEY_SYMBOL
+        | keyOrIndex indexRef
+        | {serverVersion >= 80017}? CHECK_SYMBOL identifier
+        | {serverVersion >= 80019}? CONSTRAINT_SYMBOL identifier
+    )
+    | DISABLE_SYMBOL KEYS_SYMBOL
+    | ENABLE_SYMBOL KEYS_SYMBOL
+    | ALTER_SYMBOL COLUMN_SYMBOL? columnInternalRef (
+        SET_SYMBOL DEFAULT_SYMBOL (
+            {serverVersion >= 80014}? exprWithParentheses
+            | signedLiteralOrNull
+        )
+        | DROP_SYMBOL DEFAULT_SYMBOL
+        | {serverVersion >= 80024}? SET_SYMBOL visibility
+    )
+    | ALTER_SYMBOL INDEX_SYMBOL indexRef visibility
+    | {serverVersion >= 80017}? ALTER_SYMBOL CHECK_SYMBOL identifier constraintEnforcement
+    | {serverVersion >= 80019}? ALTER_SYMBOL CONSTRAINT_SYMBOL identifier constraintEnforcement
+    | RENAME_SYMBOL COLUMN_SYMBOL columnInternalRef TO_SYMBOL identifier
+    | RENAME_SYMBOL (TO_SYMBOL | AS_SYMBOL)? tableName
+    | RENAME_SYMBOL keyOrIndex indexRef TO_SYMBOL indexName
+    | CONVERT_SYMBOL TO_SYMBOL charset (
+        {serverVersion >= 80014}? DEFAULT_SYMBOL
+        | charsetName
+    ) collate?
+    | FORCE_SYMBOL
+    | ORDER_SYMBOL BY_SYMBOL alterOrderList
+;
+
+place:
+    AFTER_SYMBOL identifier
+    | FIRST_SYMBOL
+;
+
+restrict:
+    RESTRICT_SYMBOL
+    | CASCADE_SYMBOL
+;
+
+alterOrderList:
+    identifier direction? (COMMA_SYMBOL identifier direction?)*
+;
+
+alterAlgorithmOption:
+    ALGORITHM_SYMBOL EQUAL_OPERATOR? (DEFAULT_SYMBOL | identifier)
+;
+
+alterLockOption:
+    LOCK_SYMBOL EQUAL_OPERATOR? (DEFAULT_SYMBOL | identifier)
+;
+
+indexLockAndAlgorithm:
+    alterAlgorithmOption alterLockOption?
+    | alterLockOption alterAlgorithmOption?
+;
+
+withValidation:
+    (WITH_SYMBOL | WITHOUT_SYMBOL) VALIDATION_SYMBOL
+;
+
+removePartitioning:
+    REMOVE_SYMBOL PARTITIONING_SYMBOL
+;
+
+allOrPartitionNameList:
+    ALL_SYMBOL
+    | identifierList
+;
+
+alterTablespace:
+    TABLESPACE_SYMBOL tablespaceRef (
+        (ADD_SYMBOL | DROP_SYMBOL) DATAFILE_SYMBOL textLiteral alterTablespaceOptions?
+        | RENAME_SYMBOL TO_SYMBOL identifier
+        | {serverVersion >= 80014}? alterTablespaceOptions
+    )
+;
+
+alterUndoTablespace:
+    UNDO_SYMBOL TABLESPACE_SYMBOL tablespaceRef SET_SYMBOL (
+        ACTIVE_SYMBOL
+        | INACTIVE_SYMBOL
+    ) undoTableSpaceOptions?
+;
+
+undoTableSpaceOptions:
+    undoTableSpaceOption (COMMA_SYMBOL? undoTableSpaceOption)*
+;
+
+undoTableSpaceOption:
+    tsOptionEngine
+;
+
+alterTablespaceOptions:
+    alterTablespaceOption (COMMA_SYMBOL? alterTablespaceOption)*
+;
+
+alterTablespaceOption:
+    INITIAL_SIZE_SYMBOL EQUAL_OPERATOR? sizeNumber
+    | tsOptionAutoextendSize
+    | tsOptionMaxSize
+    | tsOptionEngine
+    | tsOptionWait
+    | tsOptionEncryption
+    | {serverVersion >= 80024}? tsOptionEngineAttribute
+;
+
+changeTablespaceOption:
+    INITIAL_SIZE_SYMBOL EQUAL_OPERATOR? sizeNumber
+    | tsOptionAutoextendSize
+    | tsOptionMaxSize
+;
+
+alterView:
+    viewAlgorithm? definerClause? viewSuid? VIEW_SYMBOL viewRef viewTail
+;
+
+// This is not the full view_tail from sql_yacc.yy as we have either a view name or a view reference,
+// depending on whether we come from createView or alterView. Everything until this difference is duplicated in those rules.
+viewTail:
+    columnInternalRefList? AS_SYMBOL viewQueryBlock
+;
+
+viewQueryBlock:
+    queryExpressionWithOptLockingClauses viewCheckOption?
+;
+
+viewCheckOption:
+    WITH_SYMBOL (CASCADED_SYMBOL | LOCAL_SYMBOL)? CHECK_SYMBOL OPTION_SYMBOL
+;
+
+alterInstanceStatement:
+    INSTANCE_SYMBOL ROTATE_SYMBOL textOrIdentifier MASTER_SYMBOL KEY_SYMBOL
+    | {serverVersion >= 80024}? (
+        RELOAD_SYMBOL TLS_SYMBOL (
+            NO_SYMBOL ROLLBACK_SYMBOL ON_SYMBOL ERROR_SYMBOL
+            | FOR_SYMBOL CHANNEL_SYMBOL identifier (
+                NO_SYMBOL ROLLBACK_SYMBOL ON_SYMBOL ERROR_SYMBOL
+            )?
+        )
+        | (ENABLE_SYMBOL | DISABLE_SYMBOL) identifier identifier
+        | RELOAD_SYMBOL KEYRING_SYMBOL
+    )
+;
+
+//----------------------------------------------------------------------------------------------------------------------
+
+createStatement:
+    CREATE_SYMBOL (
+        createDatabase
+        | createTable
+        | createFunction
+        | createProcedure
+        | createUdf
+        | createLogfileGroup
+        | createView
+        | createTrigger
+        | createIndex
+        | createServer
+        | createTablespace
+        | createEvent
+        | createRole
+        | {serverVersion >= 80011}? createSpatialReference
+        | {serverVersion >= 80014}? createUndoTablespace
+    )
+;
+
+createDatabase:
+    DATABASE_SYMBOL ifNotExists? schemaName createDatabaseOption*
+;
+
+createDatabaseOption:
+    defaultCharset
+    | defaultCollation
+    | {serverVersion >= 80016}? defaultEncryption
+;
+
+createTable:
+    TEMPORARY_SYMBOL? TABLE_SYMBOL ifNotExists? tableName (
+        (OPEN_PAR_SYMBOL tableElementList CLOSE_PAR_SYMBOL)? createTableOptionsEtc?
+        | LIKE_SYMBOL tableRef
+        | OPEN_PAR_SYMBOL LIKE_SYMBOL tableRef CLOSE_PAR_SYMBOL
+    )
+;
+
+tableElementList:
+    tableElement (COMMA_SYMBOL tableElement)*
+;
+
+tableElement:
+    columnDefinition
+    | tableConstraintDef
+;
+
+duplicateAsQe:
+    (REPLACE_SYMBOL | IGNORE_SYMBOL)? asCreateQueryExpression
+;
+
+asCreateQueryExpression:
+    AS_SYMBOL? queryExpressionWithOptLockingClauses
+;
+
+queryExpressionOrParens:
+    queryExpression lockingClauseList?
+    | queryExpressionParens
+;
+
+queryExpressionWithOptLockingClauses:
+    queryExpression lockingClauseList?
+;
+
+createRoutine: // Rule for external use only.
+    CREATE_SYMBOL (createProcedure | createFunction | createUdf) SEMICOLON_SYMBOL? EOF
+;
+
+createProcedure:
+    definerClause? PROCEDURE_SYMBOL ifNotExists? procedureName OPEN_PAR_SYMBOL (
+        procedureParameter (COMMA_SYMBOL procedureParameter)*
+    )? CLOSE_PAR_SYMBOL routineCreateOption* storedRoutineBody
+;
+
+routineString:
+    textStringLiteral
+    | DOLLAR_QUOTED_STRING_TEXT
+;
+
+storedRoutineBody:
+    compoundStatement
+    //| {serverVersion >= 80032 && supportMle}? AS_SYMBOL routineString
+;
+
+createFunction:
+    definerClause? FUNCTION_SYMBOL ifNotExists? functionName OPEN_PAR_SYMBOL (
+        functionParameter (COMMA_SYMBOL functionParameter)*
+    )? CLOSE_PAR_SYMBOL RETURNS_SYMBOL typeWithOptCollate routineCreateOption* storedRoutineBody
+;
+
+createUdf:
+    AGGREGATE_SYMBOL? FUNCTION_SYMBOL ifNotExists? udfName RETURNS_SYMBOL type = (
+        STRING_SYMBOL
+        | INT_SYMBOL
+        | REAL_SYMBOL
+        | DECIMAL_SYMBOL
+    ) SONAME_SYMBOL textLiteral
+;
+
+// sp_c_chistic in the server grammar.
+routineCreateOption:
+    routineOption
+    | NOT_SYMBOL? DETERMINISTIC_SYMBOL
+;
+
+// sp_a_chistics in the server grammar.
+routineAlterOptions:
+    routineCreateOption+
+;
+
+// sp_chistic in the server grammar.
+routineOption:
+    option = COMMENT_SYMBOL textLiteral
+    | option = LANGUAGE_SYMBOL (SQL_SYMBOL | {serverVersion >= 80032}? identifier)
+    | option = NO_SYMBOL SQL_SYMBOL
+    | option = CONTAINS_SYMBOL SQL_SYMBOL
+    | option = READS_SYMBOL SQL_SYMBOL DATA_SYMBOL
+    | option = MODIFIES_SYMBOL SQL_SYMBOL DATA_SYMBOL
+    | option = SQL_SYMBOL SECURITY_SYMBOL security = (
+        DEFINER_SYMBOL
+        | INVOKER_SYMBOL
+    )
+;
+
+createIndex:
+    onlineOption? (
+        UNIQUE_SYMBOL? type = INDEX_SYMBOL indexName indexTypeClause? createIndexTarget indexOption*
+        | type = FULLTEXT_SYMBOL INDEX_SYMBOL indexName createIndexTarget fulltextIndexOption*
+        | type = SPATIAL_SYMBOL INDEX_SYMBOL indexName createIndexTarget spatialIndexOption*
+    ) indexLockAndAlgorithm?
+;
+
+indexNameAndType:
+    indexName
+    | indexName? USING_SYMBOL indexType
+    | indexName TYPE_SYMBOL indexType
+;
+
+createIndexTarget:
+    ON_SYMBOL tableRef keyListWithExpression
+;
+
+createLogfileGroup:
+    LOGFILE_SYMBOL GROUP_SYMBOL logfileGroupName ADD_SYMBOL UNDOFILE_SYMBOL textLiteral logfileGroupOptions?
+;
+
+logfileGroupOptions:
+    logfileGroupOption (COMMA_SYMBOL? logfileGroupOption)*
+;
+
+logfileGroupOption:
+    tsOptionInitialSize
+    | tsOptionUndoRedoBufferSize
+    | tsOptionNodegroup
+    | tsOptionEngine
+    | tsOptionWait
+    | tsOptionComment
+;
+
+createServer:
+    SERVER_SYMBOL serverName FOREIGN_SYMBOL DATA_SYMBOL WRAPPER_SYMBOL textOrIdentifier serverOptions
+;
+
+serverOptions:
+    OPTIONS_SYMBOL OPEN_PAR_SYMBOL serverOption (COMMA_SYMBOL serverOption)* CLOSE_PAR_SYMBOL
+;
+
+// Options for CREATE/ALTER SERVER, used for the federated storage engine.
+serverOption:
+    option = HOST_SYMBOL textLiteral
+    | option = DATABASE_SYMBOL textLiteral
+    | option = USER_SYMBOL textLiteral
+    | option = PASSWORD_SYMBOL textLiteral
+    | option = SOCKET_SYMBOL textLiteral
+    | option = OWNER_SYMBOL textLiteral
+    | option = PORT_SYMBOL ulong_number
+;
+
+createTablespace:
+    TABLESPACE_SYMBOL tablespaceName tsDataFileName (
+        USE_SYMBOL LOGFILE_SYMBOL GROUP_SYMBOL logfileGroupRef
+    )? tablespaceOptions?
+;
+
+createUndoTablespace:
+    UNDO_SYMBOL TABLESPACE_SYMBOL tablespaceName ADD_SYMBOL tsDataFile undoTableSpaceOptions?
+;
+
+tsDataFileName:
+    ADD_SYMBOL tsDataFile
+    | {serverVersion >= 80014}? (ADD_SYMBOL tsDataFile)? // now optional
+;
+
+tsDataFile:
+    DATAFILE_SYMBOL textLiteral
+;
+
+tablespaceOptions:
+    tablespaceOption (COMMA_SYMBOL? tablespaceOption)*
+;
+
+tablespaceOption:
+    tsOptionInitialSize
+    | tsOptionAutoextendSize
+    | tsOptionMaxSize
+    | tsOptionExtentSize
+    | tsOptionNodegroup
+    | tsOptionEngine
+    | tsOptionWait
+    | tsOptionComment
+    | tsOptionFileblockSize
+    | {serverVersion >= 80014}? tsOptionEncryption
+;
+
+tsOptionInitialSize:
+    INITIAL_SIZE_SYMBOL EQUAL_OPERATOR? sizeNumber
+;
+
+tsOptionUndoRedoBufferSize:
+    (UNDO_BUFFER_SIZE_SYMBOL | REDO_BUFFER_SIZE_SYMBOL) EQUAL_OPERATOR? sizeNumber
+;
+
+tsOptionAutoextendSize:
+    AUTOEXTEND_SIZE_SYMBOL EQUAL_OPERATOR? sizeNumber
+;
+
+tsOptionMaxSize:
+    MAX_SIZE_SYMBOL EQUAL_OPERATOR? sizeNumber
+;
+
+tsOptionExtentSize:
+    EXTENT_SIZE_SYMBOL EQUAL_OPERATOR? sizeNumber
+;
+
+tsOptionNodegroup:
+    NODEGROUP_SYMBOL EQUAL_OPERATOR? real_ulong_number
+;
+
+tsOptionEngine:
+    STORAGE_SYMBOL? ENGINE_SYMBOL EQUAL_OPERATOR? engineRef
+;
+
+tsOptionWait: (WAIT_SYMBOL | NO_WAIT_SYMBOL)
+;
+
+tsOptionComment:
+    COMMENT_SYMBOL EQUAL_OPERATOR? textLiteral
+;
+
+tsOptionFileblockSize:
+    FILE_BLOCK_SIZE_SYMBOL EQUAL_OPERATOR? sizeNumber
+;
+
+tsOptionEncryption:
+    ENCRYPTION_SYMBOL EQUAL_OPERATOR? textStringLiteral
+;
+
+tsOptionEngineAttribute:
+    ENGINE_SYMBOL EQUAL_OPERATOR? jsonAttribute
+;
+
+createView:
+    viewReplaceOrAlgorithm? definerClause? viewSuid? VIEW_SYMBOL viewName viewTail
+;
+
+viewReplaceOrAlgorithm:
+    OR_SYMBOL REPLACE_SYMBOL viewAlgorithm?
+    | viewAlgorithm
+;
+
+viewAlgorithm:
+    ALGORITHM_SYMBOL EQUAL_OPERATOR algorithm = (
+        UNDEFINED_SYMBOL
+        | MERGE_SYMBOL
+        | TEMPTABLE_SYMBOL
+    )
+;
+
+viewSuid:
+    SQL_SYMBOL SECURITY_SYMBOL (DEFINER_SYMBOL | INVOKER_SYMBOL)
+;
+
+createTrigger:
+    definerClause? TRIGGER_SYMBOL ifNotExists? triggerName timing = (
+        BEFORE_SYMBOL
+        | AFTER_SYMBOL
+    ) event = (INSERT_SYMBOL | UPDATE_SYMBOL | DELETE_SYMBOL) ON_SYMBOL tableRef FOR_SYMBOL EACH_SYMBOL ROW_SYMBOL
+        triggerFollowsPrecedesClause? compoundStatement
+;
+
+triggerFollowsPrecedesClause:
+    ordering = (FOLLOWS_SYMBOL | PRECEDES_SYMBOL) textOrIdentifier // not a trigger reference!
+;
+
+createEvent:
+    definerClause? EVENT_SYMBOL ifNotExists? eventName ON_SYMBOL SCHEDULE_SYMBOL schedule (
+        ON_SYMBOL COMPLETION_SYMBOL NOT_SYMBOL? PRESERVE_SYMBOL
+    )? (ENABLE_SYMBOL | DISABLE_SYMBOL (ON_SYMBOL replica)?)? (
+        COMMENT_SYMBOL textLiteral
+    )? DO_SYMBOL compoundStatement
+;
+
+createRole:
+    // The server grammar has a clear_privileges rule here, which is only used to clear internal state.
+    ROLE_SYMBOL ifNotExists? roleList
+;
+
+createSpatialReference:
+    OR_SYMBOL REPLACE_SYMBOL SPATIAL_SYMBOL REFERENCE_SYMBOL SYSTEM_SYMBOL real_ulonglong_number srsAttribute*
+    | SPATIAL_SYMBOL REFERENCE_SYMBOL SYSTEM_SYMBOL ifNotExists? real_ulonglong_number srsAttribute*
+;
+
+srsAttribute:
+    NAME_SYMBOL TEXT_SYMBOL textStringNoLinebreak
+    | DEFINITION_SYMBOL TEXT_SYMBOL textStringNoLinebreak
+    | ORGANIZATION_SYMBOL textStringNoLinebreak IDENTIFIED_SYMBOL BY_SYMBOL real_ulonglong_number
+    | DESCRIPTION_SYMBOL TEXT_SYMBOL textStringNoLinebreak
+;
+
+//----------------------------------------------------------------------------------------------------------------------
+
+dropStatement:
+    DROP_SYMBOL (
+        dropDatabase
+        | dropEvent
+        | dropFunction
+        | dropProcedure
+        | dropIndex
+        | dropLogfileGroup
+        | dropServer
+        | dropTable
+        | dropTableSpace
+        | dropTrigger
+        | dropView
+        | dropRole
+        | {serverVersion >= 80011}? dropSpatialReference
+        | {serverVersion >= 80014}? dropUndoTablespace
+    )
+;
+
+dropDatabase:
+    DATABASE_SYMBOL ifExists? schemaRef
+;
+
+dropEvent:
+    EVENT_SYMBOL ifExists? eventRef
+;
+
+dropFunction:
+    FUNCTION_SYMBOL ifExists? functionRef // Including UDFs.
+;
+
+dropProcedure:
+    PROCEDURE_SYMBOL ifExists? procedureRef
+;
+
+dropIndex:
+    onlineOption? type = INDEX_SYMBOL indexRef ON_SYMBOL tableRef indexLockAndAlgorithm?
+;
+
+dropLogfileGroup:
+    LOGFILE_SYMBOL GROUP_SYMBOL logfileGroupRef (
+        dropLogfileGroupOption (COMMA_SYMBOL? dropLogfileGroupOption)*
+    )?
+;
+
+dropLogfileGroupOption:
+    tsOptionWait
+    | tsOptionEngine
+;
+
+dropServer:
+    SERVER_SYMBOL ifExists? serverRef
+;
+
+dropTable:
+    TEMPORARY_SYMBOL? type = (TABLE_SYMBOL | TABLES_SYMBOL) ifExists? tableRefList (
+        RESTRICT_SYMBOL
+        | CASCADE_SYMBOL
+    )?
+;
+
+dropTableSpace:
+    TABLESPACE_SYMBOL tablespaceRef (
+        dropLogfileGroupOption (COMMA_SYMBOL? dropLogfileGroupOption)*
+    )?
+;
+
+dropTrigger:
+    TRIGGER_SYMBOL ifExists? triggerRef
+;
+
+dropView:
+    VIEW_SYMBOL ifExists? viewRefList (RESTRICT_SYMBOL | CASCADE_SYMBOL)?
+;
+
+dropRole:
+    ROLE_SYMBOL ifExists? roleList
+;
+
+dropSpatialReference:
+    SPATIAL_SYMBOL REFERENCE_SYMBOL SYSTEM_SYMBOL ifExists? real_ulonglong_number
+;
+
+dropUndoTablespace:
+    UNDO_SYMBOL TABLESPACE_SYMBOL tablespaceRef undoTableSpaceOptions?
+;
+
+//----------------------------------------------------------------------------------------------------------------------
+
+renameTableStatement:
+    RENAME_SYMBOL (TABLE_SYMBOL | TABLES_SYMBOL) renamePair (COMMA_SYMBOL renamePair)*
+;
+
+renamePair:
+    tableRef TO_SYMBOL tableName
+;
+
+//----------------------------------------------------------------------------------------------------------------------
+
+truncateTableStatement:
+    TRUNCATE_SYMBOL TABLE_SYMBOL? tableRef
+;
+
+//----------------------------------------------------------------------------------------------------------------------
+
+importStatement:
+    IMPORT_SYMBOL TABLE_SYMBOL FROM_SYMBOL textStringLiteralList
+;
+
+//--------------- DML statements ---------------------------------------------------------------------------------------
+
+callStatement:
+    CALL_SYMBOL procedureRef (OPEN_PAR_SYMBOL exprList? CLOSE_PAR_SYMBOL)?
+;
+
+deleteStatement:
+    withClause? DELETE_SYMBOL deleteStatementOption* (
+        FROM_SYMBOL (
+            tableAliasRefList USING_SYMBOL tableReferenceList whereClause? // Multi table variant 1.
+            | tableRef ({serverVersion >= 80017}? tableAlias)? partitionDelete? whereClause? orderClause? simpleLimitClause?
+            // Single table delete.
+        )
+        | tableAliasRefList FROM_SYMBOL tableReferenceList whereClause? // Multi table variant 2.
+    )
+;
+
+partitionDelete:
+    PARTITION_SYMBOL OPEN_PAR_SYMBOL identifierList CLOSE_PAR_SYMBOL
+;
+
+deleteStatementOption: // opt_delete_option in sql_yacc.yy, but the name collides with another rule (delete_options).
+    QUICK_SYMBOL
+    | LOW_PRIORITY_SYMBOL
+    | QUICK_SYMBOL
+    | IGNORE_SYMBOL
+;
+
+doStatement:
+    DO_SYMBOL selectItemList
+;
+
+handlerStatement:
+    HANDLER_SYMBOL (
+        tableRef OPEN_SYMBOL tableAlias?
+        | identifier (
+            CLOSE_SYMBOL
+            | READ_SYMBOL handlerReadOrScan whereClause? limitClause?
+        )
+    )
+;
+
+handlerReadOrScan:
+    (FIRST_SYMBOL | NEXT_SYMBOL) // Scan function.
+    | identifier (
+        // The rkey part.
+        (FIRST_SYMBOL | NEXT_SYMBOL | PREV_SYMBOL | LAST_SYMBOL)
+        | (
+            EQUAL_OPERATOR
+            | LESS_THAN_OPERATOR
+            | GREATER_THAN_OPERATOR
+            | LESS_OR_EQUAL_OPERATOR
+            | GREATER_OR_EQUAL_OPERATOR
+        ) OPEN_PAR_SYMBOL values CLOSE_PAR_SYMBOL
+    )
+;
+
+//----------------------------------------------------------------------------------------------------------------------
+
+insertStatement:
+    INSERT_SYMBOL insertLockOption? IGNORE_SYMBOL? INTO_SYMBOL? tableRef usePartition? (
+        insertFromConstructor valuesReference?
+        | SET_SYMBOL updateList valuesReference?
+        | insertQueryExpression
+    ) insertUpdateList?
+;
+
+insertLockOption:
+    LOW_PRIORITY_SYMBOL
+    | DELAYED_SYMBOL // Only allowed if no select is used. Check in the semantic phase.
+    | HIGH_PRIORITY_SYMBOL
+;
+
+insertFromConstructor:
+    (OPEN_PAR_SYMBOL fields? CLOSE_PAR_SYMBOL)? insertValues
+;
+
+fields:
+    insertIdentifier (COMMA_SYMBOL insertIdentifier)*
+;
+
+insertValues:
+    (VALUES_SYMBOL | VALUE_SYMBOL) valueList
+;
+
+insertQueryExpression:
+    queryExpression
+    | queryExpressionParens
+    | (OPEN_PAR_SYMBOL fields? CLOSE_PAR_SYMBOL)? queryExpressionWithOptLockingClauses
+;
+
+valueList:
+    OPEN_PAR_SYMBOL values? CLOSE_PAR_SYMBOL (
+        COMMA_SYMBOL OPEN_PAR_SYMBOL values? CLOSE_PAR_SYMBOL
+    )*
+;
+
+values:
+    (expr | DEFAULT_SYMBOL) (COMMA_SYMBOL (expr | DEFAULT_SYMBOL))*
+;
+
+valuesReference:
+    { serverVersion >= 80018}? AS_SYMBOL identifier columnInternalRefList?
+;
+
+insertUpdateList:
+    ON_SYMBOL DUPLICATE_SYMBOL KEY_SYMBOL UPDATE_SYMBOL updateList
+;
+
+//----------------------------------------------------------------------------------------------------------------------
+
+loadStatement:
+    LOAD_SYMBOL dataOrXml loadDataLock? loadFrom? LOCAL_SYMBOL? loadSourceType? textStringLiteral sourceCount? sourceOrder? (
+        REPLACE_SYMBOL
+        | IGNORE_SYMBOL
+    )? INTO_SYMBOL TABLE_SYMBOL tableRef usePartition? charsetClause? xmlRowsIdentifiedBy? fieldsClause? linesClause?
+        loadDataFileTail loadParallel? loadMemory? loadAlgorithm?
+;
+
+dataOrXml:
+    DATA_SYMBOL
+    | XML_SYMBOL
+;
+
+loadDataLock:
+    LOW_PRIORITY_SYMBOL
+    | CONCURRENT_SYMBOL
+;
+
+loadFrom:
+    {serverVersion >= 80200}? FROM_SYMBOL
+;
+
+loadSourceType:
+    INFILE_SYMBOL
+    | {serverVersion >= 80200}? (URL_SYMBOL | S3_SYMBOL)
+;
+
+sourceCount:
+    {serverVersion >= 80200}? (COUNT_SYMBOL INT_NUMBER | pureIdentifier INT_NUMBER)
+;
+
+sourceOrder:
+    {serverVersion >= 80200}? IN_SYMBOL PRIMARY_SYMBOL KEY_SYMBOL ORDER_SYMBOL
+;
+
+xmlRowsIdentifiedBy:
+    ROWS_SYMBOL IDENTIFIED_SYMBOL BY_SYMBOL textString
+;
+
+loadDataFileTail:
+    (IGNORE_SYMBOL INT_NUMBER (LINES_SYMBOL | ROWS_SYMBOL))? loadDataFileTargetList? (
+        SET_SYMBOL updateList
+    )?
+;
+
+loadDataFileTargetList:
+    OPEN_PAR_SYMBOL fieldOrVariableList? CLOSE_PAR_SYMBOL
+;
+
+fieldOrVariableList:
+    (columnRef | AT_SIGN_SYMBOL textOrIdentifier | AT_AT_SIGN_SYMBOL) (
+        COMMA_SYMBOL (
+            columnRef
+            | AT_SIGN_SYMBOL textOrIdentifier
+            | AT_TEXT_SUFFIX
+            | AT_AT_SIGN_SYMBOL
+        )
+    )*
+;
+
+loadAlgorithm:
+    {serverVersion >= 80200}? ALGORITHM_SYMBOL EQUAL_OPERATOR BULK_SYMBOL
+;
+
+loadParallel:
+    {serverVersion >= 80200}? PARALLEL_SYMBOL EQUAL_OPERATOR INT_NUMBER
+;
+
+loadMemory:
+    {serverVersion >= 80200}? MEMORY_SYMBOL EQUAL_OPERATOR sizeNumber
+;
+
+//----------------------------------------------------------------------------------------------------------------------
+
+replaceStatement:
+    REPLACE_SYMBOL (LOW_PRIORITY_SYMBOL | DELAYED_SYMBOL)? INTO_SYMBOL? tableRef usePartition? (
+        insertFromConstructor
+        | SET_SYMBOL updateList
+        | insertQueryExpression
+    )
+;
+
+//----------------------------------------------------------------------------------------------------------------------
+
+selectStatement:
+    queryExpression lockingClauseList?
+    | selectStatementWithInto
+;
+
+selectStatementWithInto:
+    OPEN_PAR_SYMBOL selectStatementWithInto CLOSE_PAR_SYMBOL
+    | queryExpression intoClause lockingClauseList?
+    | queryExpression lockingClauseList intoClause
+    | {serverVersion >= 80024 && serverVersion < 80031}? queryExpressionParens intoClause
+;
+
+queryExpression:
+    withClause? queryExpressionBody orderClause? limitClause?
+;
+
+queryExpressionBody:
+    (queryPrimary | queryExpressionParens)
+
+    // Unlimited UNIONS.
+    (
+        (UNION_SYMBOL | {serverVersion >= 80031}? (EXCEPT_SYMBOL | INTERSECT_SYMBOL)) unionOption? queryExpressionBody
+    )*
+;
+
+queryExpressionParens:
+    OPEN_PAR_SYMBOL (queryExpressionParens | queryExpressionWithOptLockingClauses) CLOSE_PAR_SYMBOL
+;
+
+queryPrimary:
+    querySpecification
+    | {serverVersion >= 80019}? tableValueConstructor
+    | {serverVersion >= 80019}? explicitTable
+;
+
+querySpecification:
+    SELECT_SYMBOL selectOption* selectItemList intoClause? fromClause? whereClause? groupByClause? havingClause? windowClause?
+        qualifyClause?
+;
+
+subquery:
+    queryExpressionParens
+;
+
+querySpecOption:
+    ALL_SYMBOL
+    | DISTINCT_SYMBOL
+    | STRAIGHT_JOIN_SYMBOL
+    | HIGH_PRIORITY_SYMBOL
+    | SQL_SMALL_RESULT_SYMBOL
+    | SQL_BIG_RESULT_SYMBOL
+    | SQL_BUFFER_RESULT_SYMBOL
+    | SQL_CALC_FOUND_ROWS_SYMBOL
+;
+
+limitClause:
+    LIMIT_SYMBOL limitOptions
+;
+
+simpleLimitClause:
+    LIMIT_SYMBOL limitOption
+;
+
+limitOptions:
+    limitOption ((COMMA_SYMBOL | OFFSET_SYMBOL) limitOption)?
+;
+
+limitOption:
+    identifier
+    | (PARAM_MARKER | ULONGLONG_NUMBER | LONG_NUMBER | INT_NUMBER)
+;
+
+intoClause:
+    INTO_SYMBOL (
+        OUTFILE_SYMBOL textStringLiteral charsetClause? fieldsClause? linesClause?
+        | DUMPFILE_SYMBOL textStringLiteral
+        | (textOrIdentifier | userVariable) (
+            COMMA_SYMBOL (textOrIdentifier | userVariable)
+        )*
+    )
+;
+
+procedureAnalyseClause:
+    PROCEDURE_SYMBOL OPEN_PAR_SYMBOL (INT_NUMBER (COMMA_SYMBOL INT_NUMBER)?)? CLOSE_PAR_SYMBOL
+;
+
+havingClause:
+    HAVING_SYMBOL expr
+;
+
+qualifyClause:
+    {serverVersion >= 80200}? QUALIFY_SYMBOL expr
+;
+
+windowClause:
+    WINDOW_SYMBOL windowDefinition (COMMA_SYMBOL windowDefinition)*
+;
+
+windowDefinition:
+    windowName AS_SYMBOL windowSpec
+;
+
+windowSpec:
+    OPEN_PAR_SYMBOL windowSpecDetails CLOSE_PAR_SYMBOL
+;
+
+windowSpecDetails:
+    windowName? (PARTITION_SYMBOL BY_SYMBOL orderList)? orderClause? windowFrameClause?
+;
+
+windowFrameClause:
+    windowFrameUnits windowFrameExtent windowFrameExclusion?
+;
+
+windowFrameUnits:
+    ROWS_SYMBOL
+    | RANGE_SYMBOL
+    | GROUPS_SYMBOL
+;
+
+windowFrameExtent:
+    windowFrameStart
+    | windowFrameBetween
+;
+
+windowFrameStart:
+    UNBOUNDED_SYMBOL PRECEDING_SYMBOL
+    | ulonglongNumber PRECEDING_SYMBOL
+    | PARAM_MARKER PRECEDING_SYMBOL
+    | INTERVAL_SYMBOL expr interval PRECEDING_SYMBOL
+    | CURRENT_SYMBOL ROW_SYMBOL
+;
+
+windowFrameBetween:
+    BETWEEN_SYMBOL windowFrameBound AND_SYMBOL windowFrameBound
+;
+
+windowFrameBound:
+    windowFrameStart
+    | UNBOUNDED_SYMBOL FOLLOWING_SYMBOL
+    | ulonglongNumber FOLLOWING_SYMBOL
+    | PARAM_MARKER FOLLOWING_SYMBOL
+    | INTERVAL_SYMBOL expr interval FOLLOWING_SYMBOL
+;
+
+windowFrameExclusion:
+    EXCLUDE_SYMBOL (
+        CURRENT_SYMBOL ROW_SYMBOL
+        | GROUP_SYMBOL
+        | TIES_SYMBOL
+        | NO_SYMBOL OTHERS_SYMBOL
+    )
+;
+
+withClause:
+    WITH_SYMBOL RECURSIVE_SYMBOL? commonTableExpression (
+        COMMA_SYMBOL commonTableExpression
+    )*
+;
+
+commonTableExpression:
+    identifier columnInternalRefList? AS_SYMBOL subquery
+;
+
+groupByClause:
+    GROUP_SYMBOL BY_SYMBOL orderList olapOption?
+    | {serverVersion >= 80032}? GROUP_SYMBOL BY_SYMBOL (ROLLUP_SYMBOL | CUBE_SYMBOL) OPEN_PAR_SYMBOL groupList CLOSE_PAR_SYMBOL
+;
+
+olapOption:
+    WITH_SYMBOL ROLLUP_SYMBOL
+;
+
+orderClause:
+    ORDER_SYMBOL BY_SYMBOL orderList
+;
+
+direction:
+    ASC_SYMBOL
+    | DESC_SYMBOL
+;
+
+fromClause:
+    FROM_SYMBOL (DUAL_SYMBOL | tableReferenceList)
+;
+
+tableReferenceList:
+    tableReference (COMMA_SYMBOL tableReference)*
+;
+
+tableValueConstructor:
+    VALUES_SYMBOL rowValueExplicit (COMMA_SYMBOL rowValueExplicit)*
+;
+
+explicitTable:
+    TABLE_SYMBOL tableRef
+;
+
+rowValueExplicit:
+    ROW_SYMBOL OPEN_PAR_SYMBOL values? CLOSE_PAR_SYMBOL
+;
+
+selectOption:
+    querySpecOption
+    | SQL_NO_CACHE_SYMBOL // Deprecated and ignored in 8.0.
+;
+
+lockingClauseList:
+    {serverVersion >= 80031}? lockingClause+
+;
+
+lockingClause:
+    FOR_SYMBOL lockStrengh (OF_SYMBOL tableAliasRefList)? lockedRowAction?
+    | LOCK_SYMBOL IN_SYMBOL SHARE_SYMBOL MODE_SYMBOL
+;
+
+lockStrengh:
+    UPDATE_SYMBOL
+    | SHARE_SYMBOL
+;
+
+lockedRowAction:
+    SKIP_SYMBOL LOCKED_SYMBOL
+    | NOWAIT_SYMBOL
+;
+
+selectItemList: (selectItem | MULT_OPERATOR) (COMMA_SYMBOL selectItem)*
+;
+
+selectItem:
+    tableWild
+    | expr selectAlias?
+;
+
+selectAlias:
+    AS_SYMBOL? (identifier | textStringLiteral)
+;
+
+whereClause:
+    WHERE_SYMBOL expr
+;
+
+tableReference: // Note: we have also a tableRef rule for identifiers that reference a table anywhere.
+    (
+        tableFactor
+        // ODBC syntax
+        | OPEN_CURLY_SYMBOL ({serverVersion < 80017}? identifier | OJ_SYMBOL) escapedTableReference CLOSE_CURLY_SYMBOL
+    ) joinedTable*
+;
+
+escapedTableReference:
+    tableFactor joinedTable*
+;
+
+joinedTable: // Same as joined_table in sql_yacc.yy, but with removed left recursion.
+    innerJoinType tableReference (
+        ON_SYMBOL expr
+        | USING_SYMBOL identifierListWithParentheses
+    )?
+    | outerJoinType tableReference (
+        ON_SYMBOL expr
+        | USING_SYMBOL identifierListWithParentheses
+    )
+    | naturalJoinType tableFactor
+;
+
+naturalJoinType:
+    NATURAL_SYMBOL INNER_SYMBOL? JOIN_SYMBOL
+    | NATURAL_SYMBOL (LEFT_SYMBOL | RIGHT_SYMBOL) OUTER_SYMBOL? JOIN_SYMBOL
+;
+
+innerJoinType:
+    type = (INNER_SYMBOL | CROSS_SYMBOL)? JOIN_SYMBOL
+    | type = STRAIGHT_JOIN_SYMBOL
+;
+
+outerJoinType:
+    type = (LEFT_SYMBOL | RIGHT_SYMBOL) OUTER_SYMBOL? JOIN_SYMBOL
+;
+
+tableFactor:
+    singleTable
+    | singleTableParens
+    | derivedTable
+    | tableReferenceListParens
+    | {serverVersion >= 80004}? tableFunction
+;
+
+singleTable:
+    tableRef usePartition? tableAlias? indexHintList? tablesampleClause?
+;
+
+singleTableParens:
+    OPEN_PAR_SYMBOL (singleTable | singleTableParens) CLOSE_PAR_SYMBOL
+;
+
+derivedTable:
+    subquery tableAlias? columnInternalRefList?
+    | {serverVersion >= 80014}? LATERAL_SYMBOL subquery tableAlias? columnInternalRefList?
+;
+
+// This rule covers both: joined_table_parens and table_reference_list_parens from sql_yacc.yy.
+// We can simplify that because we have unrolled the indirect left recursion in joined_table <-> table_reference.
+tableReferenceListParens:
+    OPEN_PAR_SYMBOL (tableReferenceList | tableReferenceListParens) CLOSE_PAR_SYMBOL
+;
+
+tableFunction:
+    JSON_TABLE_SYMBOL OPEN_PAR_SYMBOL expr COMMA_SYMBOL textStringLiteral columnsClause CLOSE_PAR_SYMBOL tableAlias?
+;
+
+columnsClause:
+    COLUMNS_SYMBOL OPEN_PAR_SYMBOL jtColumn (COMMA_SYMBOL jtColumn)* CLOSE_PAR_SYMBOL
+;
+
+jtColumn:
+    identifier FOR_SYMBOL ORDINALITY_SYMBOL
+    | identifier dataType ({serverVersion >= 80014}? collate)? EXISTS_SYMBOL? PATH_SYMBOL textStringLiteral
+        onEmptyOrErrorJsonTable?
+    | NESTED_SYMBOL PATH_SYMBOL textStringLiteral columnsClause
+;
+
+onEmptyOrError:
+    onEmpty onError?
+    | onError
+;
+
+// One variation of the empty/error syntax that is going to be deprecated, but currently still allowed.
+onEmptyOrErrorJsonTable:
+    onEmptyOrError
+    | onError onEmpty
+;
+
+onEmpty:
+    jsonOnResponse ON_SYMBOL EMPTY_SYMBOL
+;
+
+onError:
+    jsonOnResponse ON_SYMBOL ERROR_SYMBOL
+;
+
+jsonOnResponse:
+    ERROR_SYMBOL
+    | NULL_SYMBOL
+    | DEFAULT_SYMBOL textStringLiteral
+;
+
+unionOption:
+    DISTINCT_SYMBOL
+    | ALL_SYMBOL
+;
+
+tableAlias:
+    (AS_SYMBOL | {serverVersion < 80017}? EQUAL_OPERATOR)? identifier
+;
+
+indexHintList:
+    indexHint (COMMA_SYMBOL indexHint)*
+;
+
+indexHint:
+    indexHintType keyOrIndex indexHintClause? OPEN_PAR_SYMBOL indexList CLOSE_PAR_SYMBOL
+    | USE_SYMBOL keyOrIndex indexHintClause? OPEN_PAR_SYMBOL indexList? CLOSE_PAR_SYMBOL
+;
+
+indexHintType:
+    FORCE_SYMBOL
+    | IGNORE_SYMBOL
+;
+
+keyOrIndex:
+    KEY_SYMBOL
+    | INDEX_SYMBOL
+;
+
+constraintKeyType:
+    PRIMARY_SYMBOL KEY_SYMBOL
+    | UNIQUE_SYMBOL keyOrIndex?
+;
+
+indexHintClause:
+    FOR_SYMBOL (JOIN_SYMBOL | ORDER_SYMBOL BY_SYMBOL | GROUP_SYMBOL BY_SYMBOL)
+;
+
+indexList:
+    indexListElement (COMMA_SYMBOL indexListElement)*
+;
+
+indexListElement:
+    identifier
+    | PRIMARY_SYMBOL
+;
+
+//----------------------------------------------------------------------------------------------------------------------
+
+updateStatement:
+    withClause? UPDATE_SYMBOL LOW_PRIORITY_SYMBOL? IGNORE_SYMBOL? tableReferenceList SET_SYMBOL updateList whereClause?
+        orderClause? simpleLimitClause?
+;
+
+//----------------------------------------------------------------------------------------------------------------------
+
+transactionOrLockingStatement:
+    transactionStatement
+    | savepointStatement
+    | lockStatement
+    | xaStatement
+;
+
+transactionStatement:
+    START_SYMBOL TRANSACTION_SYMBOL startTransactionOptionList*
+    | COMMIT_SYMBOL WORK_SYMBOL? (AND_SYMBOL NO_SYMBOL? CHAIN_SYMBOL)? (
+        NO_SYMBOL? RELEASE_SYMBOL
+    )?
+    // SET TRANSACTION is part of setStatement.
+;
+
+// BEGIN WORK is separated from transactional statements as it must not appear as part of a stored program.
+beginWork:
+    BEGIN_SYMBOL WORK_SYMBOL?
+;
+
+startTransactionOptionList:
+    WITH_SYMBOL CONSISTENT_SYMBOL SNAPSHOT_SYMBOL
+    | READ_SYMBOL (WRITE_SYMBOL | ONLY_SYMBOL)
+;
+
+savepointStatement:
+    SAVEPOINT_SYMBOL identifier
+    | ROLLBACK_SYMBOL WORK_SYMBOL? (
+        TO_SYMBOL SAVEPOINT_SYMBOL? identifier
+        | (AND_SYMBOL NO_SYMBOL? CHAIN_SYMBOL)? (NO_SYMBOL? RELEASE_SYMBOL)?
+    )
+    | RELEASE_SYMBOL SAVEPOINT_SYMBOL identifier
+;
+
+lockStatement:
+    LOCK_SYMBOL (TABLES_SYMBOL | TABLE_SYMBOL) lockItem (COMMA_SYMBOL lockItem)*
+    | LOCK_SYMBOL INSTANCE_SYMBOL FOR_SYMBOL BACKUP_SYMBOL
+    | UNLOCK_SYMBOL ( TABLES_SYMBOL | TABLE_SYMBOL | INSTANCE_SYMBOL)
+;
+
+lockItem:
+    tableRef tableAlias? lockOption
+;
+
+lockOption:
+    READ_SYMBOL LOCAL_SYMBOL?
+    | LOW_PRIORITY_SYMBOL? WRITE_SYMBOL // low priority deprecated since 5.7
+;
+
+xaStatement:
+    XA_SYMBOL (
+        (START_SYMBOL | BEGIN_SYMBOL) xid (JOIN_SYMBOL | RESUME_SYMBOL)?
+        | END_SYMBOL xid (SUSPEND_SYMBOL (FOR_SYMBOL MIGRATE_SYMBOL)?)?
+        | PREPARE_SYMBOL xid
+        | COMMIT_SYMBOL xid (ONE_SYMBOL PHASE_SYMBOL)?
+        | ROLLBACK_SYMBOL xid
+        | RECOVER_SYMBOL xaConvert?
+    )
+;
+
+xaConvert:
+    CONVERT_SYMBOL XID_SYMBOL
+;
+
+xid:
+    textString (COMMA_SYMBOL textString (COMMA_SYMBOL ulong_number)?)?
+;
+
+//----------------------------------------------------------------------------------------------------------------------
+
+replicationStatement:
+    PURGE_SYMBOL purgeOptions
+    | changeSource
+    | RESET_SYMBOL resetOption (COMMA_SYMBOL resetOption)*
+    | RESET_SYMBOL PERSIST_SYMBOL ifExistsIdentifier?
+    | startReplicaStatement
+    | stopReplicaStatement
+    | changeReplication
+    | replicationLoad
+    | groupReplication
+;
+
+purgeOptions:
+    (BINARY_SYMBOL | MASTER_SYMBOL) LOGS_SYMBOL (
+        TO_SYMBOL textLiteral
+        | BEFORE_SYMBOL expr
+    )
+;
+
+resetOption:
+    masterOrBinaryLogsAndGtids sourceResetOptions?
+    | replica ALL_SYMBOL? channel?
+;
+
+masterOrBinaryLogsAndGtids:
+    MASTER_SYMBOL
+    | {serverVersion >= 80032}? BINARY_SYMBOL LOGS_SYMBOL AND_SYMBOL GTIDS_SYMBOL
+;
+
+sourceResetOptions:
+    TO_SYMBOL real_ulonglong_number
+;
+
+replicationLoad:
+    LOAD_SYMBOL (DATA_SYMBOL | TABLE_SYMBOL tableRef) FROM_SYMBOL MASTER_SYMBOL
+;
+
+changeReplicationSource:
+    MASTER_SYMBOL
+    | {serverVersion >= 80024}? REPLICATION_SYMBOL SOURCE_SYMBOL
+;
+
+changeSource:
+    CHANGE_SYMBOL changeReplicationSource TO_SYMBOL sourceDefinitions channel?
+;
+
+sourceDefinitions:
+    sourceDefinition (COMMA_SYMBOL sourceDefinition)*
+;
+
+sourceDefinition: // source_def in sql_yacc.yy
+    changeReplicationSourceHost EQUAL_OPERATOR textStringNoLinebreak
+    | NETWORK_NAMESPACE_SYMBOL EQUAL_OPERATOR textStringNoLinebreak
+    | changeReplicationSourceBind EQUAL_OPERATOR textStringNoLinebreak
+    | changeReplicationSourceUser EQUAL_OPERATOR textStringNoLinebreak
+    | changeReplicationSourcePassword EQUAL_OPERATOR textStringNoLinebreak
+    | changeReplicationSourcePort EQUAL_OPERATOR ulong_number
+    | changeReplicationSourceConnectRetry EQUAL_OPERATOR ulong_number
+    | changeReplicationSourceRetryCount EQUAL_OPERATOR ulong_number
+    | changeReplicationSourceDelay EQUAL_OPERATOR ulong_number
+    | changeReplicationSourceSSL EQUAL_OPERATOR ulong_number
+    | changeReplicationSourceSSLCA EQUAL_OPERATOR textStringNoLinebreak
+    | changeReplicationSourceSSLCApath EQUAL_OPERATOR textStringNoLinebreak
+    | changeReplicationSourceTLSVersion EQUAL_OPERATOR textStringNoLinebreak
+    | changeReplicationSourceSSLCert EQUAL_OPERATOR textStringNoLinebreak
+    | changeReplicationSourceTLSCiphersuites EQUAL_OPERATOR sourceTlsCiphersuitesDef
+    | changeReplicationSourceSSLCipher EQUAL_OPERATOR textStringNoLinebreak
+    | changeReplicationSourceSSLKey EQUAL_OPERATOR textStringNoLinebreak
+    | changeReplicationSourceSSLVerifyServerCert EQUAL_OPERATOR ulong_number
+    | changeReplicationSourceSSLCLR EQUAL_OPERATOR textLiteral
+    | changeReplicationSourceSSLCLRpath EQUAL_OPERATOR textStringNoLinebreak
+    | changeReplicationSourcePublicKey EQUAL_OPERATOR textStringNoLinebreak
+    | changeReplicationSourceGetSourcePublicKey EQUAL_OPERATOR ulong_number
+    | changeReplicationSourceHeartbeatPeriod EQUAL_OPERATOR ulong_number
+    | IGNORE_SERVER_IDS_SYMBOL EQUAL_OPERATOR serverIdList
+    | changeReplicationSourceCompressionAlgorithm EQUAL_OPERATOR textStringLiteral
+    | changeReplicationSourceZstdCompressionLevel EQUAL_OPERATOR ulong_number
+    | changeReplicationSourceAutoPosition EQUAL_OPERATOR ulong_number
+    | PRIVILEGE_CHECKS_USER_SYMBOL EQUAL_OPERATOR privilegeCheckDef
+    | REQUIRE_ROW_FORMAT_SYMBOL EQUAL_OPERATOR ulong_number
+    | REQUIRE_TABLE_PRIMARY_KEY_CHECK_SYMBOL EQUAL_OPERATOR tablePrimaryKeyCheckDef
+    | {serverVersion >= 80024}? SOURCE_CONNECTION_AUTO_FAILOVER_SYMBOL EQUAL_OPERATOR real_ulong_number
+    | {serverVersion >= 80024}? ASSIGN_GTIDS_TO_ANONYMOUS_TRANSACTIONS_SYMBOL EQUAL_OPERATOR
+        assignGtidsToAnonymousTransactionsDefinition
+    | {serverVersion >= 80027}? GTID_ONLY_SYMBOL EQUAL_OPERATOR real_ulong_number
+    | sourceFileDef
+;
+
+changeReplicationSourceAutoPosition:
+    MASTER_AUTO_POSITION_SYMBOL
+    | SOURCE_AUTO_POSITION_SYMBOL
+;
+
+changeReplicationSourceHost:
+    MASTER_HOST_SYMBOL
+    | SOURCE_HOST_SYMBOL
+;
+
+changeReplicationSourceBind:
+    MASTER_BIND_SYMBOL
+    | SOURCE_BIND_SYMBOL
+;
+
+changeReplicationSourceUser:
+    MASTER_USER_SYMBOL
+    | SOURCE_USER_SYMBOL
+;
+
+changeReplicationSourcePassword:
+    MASTER_PASSWORD_SYMBOL
+    | SOURCE_PASSWORD_SYMBOL
+;
+
+changeReplicationSourcePort:
+    MASTER_PORT_SYMBOL
+    | SOURCE_PORT_SYMBOL
+;
+
+changeReplicationSourceConnectRetry:
+    MASTER_CONNECT_RETRY_SYMBOL
+    | SOURCE_CONNECT_RETRY_SYMBOL
+;
+
+changeReplicationSourceRetryCount:
+    MASTER_RETRY_COUNT_SYMBOL
+    | SOURCE_RETRY_COUNT_SYMBOL
+;
+
+changeReplicationSourceDelay:
+    MASTER_DELAY_SYMBOL
+    | SOURCE_DELAY_SYMBOL
+;
+
+changeReplicationSourceSSL:
+    MASTER_SSL_SYMBOL
+    | SOURCE_SSL_SYMBOL
+;
+
+changeReplicationSourceSSLCA:
+    MASTER_SSL_CA_SYMBOL
+    | SOURCE_SSL_CA_SYMBOL
+;
+
+changeReplicationSourceSSLCApath:
+    MASTER_SSL_CAPATH_SYMBOL
+    | SOURCE_SSL_CAPATH_SYMBOL
+;
+
+changeReplicationSourceSSLCipher:
+    MASTER_SSL_CIPHER_SYMBOL
+    | SOURCE_SSL_CIPHER_SYMBOL
+;
+
+changeReplicationSourceSSLCLR:
+    MASTER_SSL_CRL_SYMBOL
+    | SOURCE_SSL_CRL_SYMBOL
+;
+
+changeReplicationSourceSSLCLRpath:
+    MASTER_SSL_CRLPATH_SYMBOL
+    | SOURCE_SSL_CRLPATH_SYMBOL
+;
+
+changeReplicationSourceSSLKey:
+    MASTER_SSL_KEY_SYMBOL
+    | SOURCE_SSL_KEY_SYMBOL
+;
+
+changeReplicationSourceSSLVerifyServerCert:
+    MASTER_SSL_VERIFY_SERVER_CERT_SYMBOL
+    | SOURCE_SSL_VERIFY_SERVER_CERT_SYMBOL
+;
+
+changeReplicationSourceTLSVersion:
+    MASTER_TLS_VERSION_SYMBOL
+    | SOURCE_TLS_VERSION_SYMBOL
+;
+
+changeReplicationSourceTLSCiphersuites:
+    MASTER_TLS_CIPHERSUITES_SYMBOL
+    | SOURCE_TLS_CIPHERSUITES_SYMBOL
+;
+
+changeReplicationSourceSSLCert:
+    MASTER_SSL_CERT_SYMBOL
+    | SOURCE_SSL_CERT_SYMBOL
+;
+
+changeReplicationSourcePublicKey:
+    MASTER_PUBLIC_KEY_PATH_SYMBOL
+    | SOURCE_PUBLIC_KEY_PATH_SYMBOL
+;
+
+changeReplicationSourceGetSourcePublicKey:
+    GET_MASTER_PUBLIC_KEY_SYMBOL
+    | GET_SOURCE_PUBLIC_KEY_SYMBOL
+;
+
+changeReplicationSourceHeartbeatPeriod:
+    MASTER_HEARTBEAT_PERIOD_SYMBOL
+    | SOURCE_HEARTBEAT_PERIOD_SYMBOL
+;
+
+changeReplicationSourceCompressionAlgorithm:
+    MASTER_COMPRESSION_ALGORITHM_SYMBOL
+    | SOURCE_COMPRESSION_ALGORITHM_SYMBOL
+;
+
+changeReplicationSourceZstdCompressionLevel:
+    MASTER_ZSTD_COMPRESSION_LEVEL_SYMBOL
+    | SOURCE_ZSTD_COMPRESSION_LEVEL_SYMBOL
+;
+
+privilegeCheckDef:
+    userIdentifierOrText
+    | NULL_SYMBOL
+;
+
+tablePrimaryKeyCheckDef:
+    STREAM_SYMBOL
+    | ON_SYMBOL
+    | OFF_SYMBOL
+    | GENERATE_SYMBOL
+;
+
+assignGtidsToAnonymousTransactionsDefinition:
+    OFF_SYMBOL
+    | LOCAL_SYMBOL
+    | textStringLiteral
+;
+
+sourceTlsCiphersuitesDef:
+    textStringNoLinebreak
+    | NULL_SYMBOL
+;
+
+sourceFileDef:
+    sourceLogFile EQUAL_OPERATOR textStringNoLinebreak
+    | sourceLogPos EQUAL_OPERATOR ulonglongNumber
+    | RELAY_LOG_FILE_SYMBOL EQUAL_OPERATOR textStringNoLinebreak
+    | RELAY_LOG_POS_SYMBOL EQUAL_OPERATOR ulong_number
+;
+
+sourceLogFile:
+    MASTER_LOG_FILE_SYMBOL
+    | SOURCE_LOG_FILE_SYMBOL
+;
+
+sourceLogPos:
+    MASTER_LOG_POS_SYMBOL
+    | SOURCE_LOG_POS_SYMBOL
+;
+
+serverIdList:
+    OPEN_PAR_SYMBOL (ulong_number (COMMA_SYMBOL ulong_number)*)? CLOSE_PAR_SYMBOL
+;
+
+changeReplication:
+    CHANGE_SYMBOL REPLICATION_SYMBOL FILTER_SYMBOL filterDefinition (
+        COMMA_SYMBOL filterDefinition
+    )* channel?
+;
+
+filterDefinition:
+    REPLICATE_DO_DB_SYMBOL EQUAL_OPERATOR OPEN_PAR_SYMBOL filterDbList? CLOSE_PAR_SYMBOL
+    | REPLICATE_IGNORE_DB_SYMBOL EQUAL_OPERATOR OPEN_PAR_SYMBOL filterDbList? CLOSE_PAR_SYMBOL
+    | REPLICATE_DO_TABLE_SYMBOL EQUAL_OPERATOR OPEN_PAR_SYMBOL filterTableList? CLOSE_PAR_SYMBOL
+    | REPLICATE_IGNORE_TABLE_SYMBOL EQUAL_OPERATOR OPEN_PAR_SYMBOL filterTableList? CLOSE_PAR_SYMBOL
+    | REPLICATE_WILD_DO_TABLE_SYMBOL EQUAL_OPERATOR OPEN_PAR_SYMBOL filterStringList? CLOSE_PAR_SYMBOL
+    | REPLICATE_WILD_IGNORE_TABLE_SYMBOL EQUAL_OPERATOR OPEN_PAR_SYMBOL filterStringList? CLOSE_PAR_SYMBOL
+    | REPLICATE_REWRITE_DB_SYMBOL EQUAL_OPERATOR OPEN_PAR_SYMBOL filterDbPairList? CLOSE_PAR_SYMBOL
+;
+
+filterDbList:
+    schemaRef (COMMA_SYMBOL schemaRef)*
+;
+
+filterTableList:
+    filterTableRef (COMMA_SYMBOL filterTableRef)*
+;
+
+filterStringList:
+    filterWildDbTableString (COMMA_SYMBOL filterWildDbTableString)*
+;
+
+filterWildDbTableString:
+    textStringNoLinebreak // sql_yacc.yy checks for the existance of at least one dot char in the string.
+;
+
+filterDbPairList:
+    schemaIdentifierPair (COMMA_SYMBOL schemaIdentifierPair)*
+;
+
+startReplicaStatement:
+    START_SYMBOL replica replicaThreadOptions? (UNTIL_SYMBOL replicaUntil)? userOption? passwordOption? defaultAuthOption?
+        pluginDirOption? channel?
+;
+
+stopReplicaStatement:
+    STOP_SYMBOL replica replicaThreadOptions? channel?
+;
+
+replicaUntil:
+    (
+        sourceFileDef
+        | (SQL_BEFORE_GTIDS_SYMBOL | SQL_AFTER_GTIDS_SYMBOL) EQUAL_OPERATOR textString
+        | SQL_AFTER_MTS_GAPS_SYMBOL
+    ) (COMMA_SYMBOL sourceFileDef)*
+;
+
+userOption:
+    USER_SYMBOL EQUAL_OPERATOR textString
+;
+
+passwordOption:
+    PASSWORD_SYMBOL EQUAL_OPERATOR textString
+;
+
+defaultAuthOption:
+    DEFAULT_AUTH_SYMBOL EQUAL_OPERATOR textString
+;
+
+pluginDirOption:
+    PLUGIN_DIR_SYMBOL EQUAL_OPERATOR textString
+;
+
+replicaThreadOptions:
+    replicaThreadOption (COMMA_SYMBOL replicaThreadOption)*
+;
+
+replicaThreadOption:
+    SQL_THREAD_SYMBOL
+    | RELAY_THREAD_SYMBOL
+;
+
+groupReplication:
+    (START_SYMBOL groupReplicationStartOptions? | STOP_SYMBOL) GROUP_REPLICATION_SYMBOL
+;
+
+groupReplicationStartOptions:
+    groupReplicationStartOption (COMMA_SYMBOL groupReplicationStartOption)*
+;
+
+groupReplicationStartOption:
+    groupReplicationUser
+    | groupReplicationPassword
+    | groupReplicationPluginAuth
+;
+
+groupReplicationUser:
+    USER_SYMBOL EQUAL_OPERATOR textStringNoLinebreak
+;
+
+groupReplicationPassword:
+    PASSWORD_SYMBOL EQUAL_OPERATOR textStringNoLinebreak
+;
+
+groupReplicationPluginAuth:
+    DEFAULT_AUTH_SYMBOL EQUAL_OPERATOR textStringNoLinebreak
+;
+
+replica: // Part of the terminology cleanup starting with 8.0.24.
+    SLAVE_SYMBOL
+    | REPLICA_SYMBOL
+;
+
+//----------------------------------------------------------------------------------------------------------------------
+
+preparedStatement:
+    type = PREPARE_SYMBOL identifier FROM_SYMBOL (textLiteral | userVariable)
+    | executeStatement
+    | type = (DEALLOCATE_SYMBOL | DROP_SYMBOL) PREPARE_SYMBOL identifier
+;
+
+executeStatement:
+    EXECUTE_SYMBOL identifier (USING_SYMBOL executeVarList)?
+;
+
+executeVarList:
+    userVariable (COMMA_SYMBOL userVariable)*
+;
+
+//----------------------------------------------------------------------------------------------------------------------
+
+cloneStatement:
+    CLONE_SYMBOL (
+        LOCAL_SYMBOL DATA_SYMBOL DIRECTORY_SYMBOL equal? textStringLiteral
+        // Clone remote has been removed in 8.0.14. This alt is taken out by the conditional REMOTE_SYMBOL.
+        | REMOTE_SYMBOL (FOR_SYMBOL REPLICATION_SYMBOL)?
+        | {serverVersion >= 80014}? INSTANCE_SYMBOL FROM_SYMBOL user COLON_SYMBOL ulong_number IDENTIFIED_SYMBOL BY_SYMBOL
+            textStringLiteral dataDirSSL?
+    )
+;
+
+dataDirSSL:
+    ssl
+    | DATA_SYMBOL DIRECTORY_SYMBOL equal? textStringLiteral ssl?
+;
+
+ssl:
+    REQUIRE_SYMBOL NO_SYMBOL? SSL_SYMBOL
+;
+
+//----------------------------------------------------------------------------------------------------------------------
+
+// Note: SET PASSWORD is part of the SET statement.
+accountManagementStatement:
+    alterUserStatement
+    | createUserStatement
+    | dropUserStatement
+    | grantStatement
+    | renameUserStatement
+    | revokeStatement
+    | setRoleStatement
+;
+
+alterUserStatement:
+    ALTER_SYMBOL USER_SYMBOL ifExists? (
+        (
+            {serverVersion < 80014}? createUserList
+            | {serverVersion >= 80014}? alterUserList
+        ) createUserTail
+        | userFunction (
+            (identifiedByRandomPassword | identifiedByPassword) replacePassword? retainCurrentPassword?
+            | DISCARD_SYMBOL OLD_SYMBOL PASSWORD_SYMBOL
+            | userRegistration?
+        )
+        | user (
+            DEFAULT_SYMBOL ROLE_SYMBOL (ALL_SYMBOL | NONE_SYMBOL | roleList)
+            | userRegistration?
+        )
+    )
+;
+
+alterUserList:
+    alterUser (COMMA_SYMBOL alterUser)*
+;
+
+alterUser:
+    {serverVersion < 80025}? oldAlterUser
+    | {serverVersion >= 80025}? (
+        user (
+            identifiedByPassword (
+                REPLACE_SYMBOL textStringLiteral retainCurrentPassword?
+                | retainCurrentPassword?
+            )
+            | identifiedByRandomPassword (
+                retainCurrentPassword?
+                | REPLACE_SYMBOL textStringLiteral retainCurrentPassword?
+            )
+            | identifiedWithPlugin
+            | identifiedWithPluginAsAuth retainCurrentPassword?
+            | identifiedWithPluginByPassword (
+                REPLACE_SYMBOL textStringLiteral retainCurrentPassword?
+                | retainCurrentPassword?
+            )
+            | identifiedWithPluginByRandomPassword retainCurrentPassword?
+            | discardOldPassword?
+            | ADD_SYMBOL factor identification (ADD_SYMBOL factor identification)?
+            | MODIFY_SYMBOL factor identification (
+                MODIFY_SYMBOL factor identification
+            )?
+            | DROP_SYMBOL factor (DROP_SYMBOL factor)?
+        )
+    )
+;
+
+oldAlterUser:
+    user IDENTIFIED_SYMBOL BY_SYMBOL (
+        textString REPLACE_SYMBOL textString retainCurrentPassword?
+        | textString retainCurrentPassword?
+        | RANDOM_SYMBOL PASSWORD_SYMBOL (REPLACE_SYMBOL textString)? retainCurrentPassword?
+    )
+    | user IDENTIFIED_SYMBOL WITH_SYMBOL (
+        textOrIdentifier (
+            BY_SYMBOL textString REPLACE_SYMBOL textString retainCurrentPassword?
+            | AS_SYMBOL textStringHash retainCurrentPassword?
+            | BY_SYMBOL textString retainCurrentPassword?
+            | BY_SYMBOL RANDOM_SYMBOL PASSWORD_SYMBOL retainCurrentPassword?
+        )?
+    )
+    | user discardOldPassword?
+;
+
+userFunction:
+    USER_SYMBOL parentheses
+;
+
+createUserStatement:
+    CREATE_SYMBOL USER_SYMBOL ifNotExists? createUserList defaultRoleClause? createUserTail
+;
+
+createUserTail:
+    requireClause? connectOptions? accountLockPasswordExpireOptions* (
+        {serverVersion >= 80024}? userAttributes
+    )?
+;
+
+userAttributes:
+    ATTRIBUTE_SYMBOL textStringLiteral
+    | COMMENT_SYMBOL textStringLiteral
+;
+
+defaultRoleClause:
+    DEFAULT_SYMBOL ROLE_SYMBOL roleList
+;
+
+requireClause:
+    REQUIRE_SYMBOL (requireList | option = (SSL_SYMBOL | X509_SYMBOL | NONE_SYMBOL))
+;
+
+connectOptions:
+    WITH_SYMBOL (
+        MAX_QUERIES_PER_HOUR_SYMBOL ulong_number
+        | MAX_UPDATES_PER_HOUR_SYMBOL ulong_number
+        | MAX_CONNECTIONS_PER_HOUR_SYMBOL ulong_number
+        | MAX_USER_CONNECTIONS_SYMBOL ulong_number
+    )+
+;
+
+accountLockPasswordExpireOptions:
+    ACCOUNT_SYMBOL (LOCK_SYMBOL | UNLOCK_SYMBOL)
+    | PASSWORD_SYMBOL (
+        EXPIRE_SYMBOL (
+            INTERVAL_SYMBOL real_ulong_number DAY_SYMBOL
+            | NEVER_SYMBOL
+            | DEFAULT_SYMBOL
+        )?
+        | HISTORY_SYMBOL (real_ulong_number | DEFAULT_SYMBOL)
+        | REUSE_SYMBOL INTERVAL_SYMBOL (
+            real_ulong_number DAY_SYMBOL
+            | DEFAULT_SYMBOL
+        )
+        | {serverVersion >= 80014}? REQUIRE_SYMBOL CURRENT_SYMBOL (
+            DEFAULT_SYMBOL
+            | OPTIONAL_SYMBOL
+        )?
+    )
+    | FAILED_LOGIN_ATTEMPTS_SYMBOL real_ulong_number
+    | PASSWORD_LOCK_TIME_SYMBOL (real_ulong_number | UNBOUNDED_SYMBOL)
+;
+
+userAttribute:
+    | ATTRIBUTE_SYMBOL textStringLiteral
+    | COMMENT_SYMBOL textStringLiteral
+;
+
+dropUserStatement:
+    DROP_SYMBOL USER_SYMBOL ifExists? userList
+;
+
+grantStatement:
+    GRANT_SYMBOL (
+        roleOrPrivilegesList TO_SYMBOL userList (
+            WITH_SYMBOL ADMIN_SYMBOL OPTION_SYMBOL
+        )?
+        | (roleOrPrivilegesList | ALL_SYMBOL PRIVILEGES_SYMBOL?) ON_SYMBOL aclType? grantIdentifier TO_SYMBOL grantTargetList
+            versionedRequireClause? grantOptions? grantAs?
+        | PROXY_SYMBOL ON_SYMBOL user TO_SYMBOL grantTargetList (
+            WITH_SYMBOL GRANT_SYMBOL OPTION_SYMBOL
+        )?
+    )
+;
+
+grantTargetList:
+    {serverVersion < 80011}? createUserList
+    | {serverVersion >= 80011}? userList
+;
+
+grantOptions:
+    WITH_SYMBOL grantOption
+;
+
+exceptRoleList:
+    EXCEPT_SYMBOL roleList
+;
+
+withRoles:
+    WITH_SYMBOL ROLE_SYMBOL (
+        roleList
+        | ALL_SYMBOL exceptRoleList?
+        | NONE_SYMBOL
+        | DEFAULT_SYMBOL
+    )
+;
+
+grantAs:
+    AS_SYMBOL USER_SYMBOL withRoles?
+;
+
+versionedRequireClause:
+    {serverVersion < 80011}? requireClause
+;
+
+renameUserStatement:
+    RENAME_SYMBOL USER_SYMBOL user TO_SYMBOL user (COMMA_SYMBOL user TO_SYMBOL user)*
+;
+
+revokeStatement:
+    REVOKE_SYMBOL ({serverVersion >= 80031}? ifExists)? (
+        roleOrPrivilegesList FROM_SYMBOL userList
+        | roleOrPrivilegesList ON_SYMBOL aclType? grantIdentifier FROM_SYMBOL userList
+        | ALL_SYMBOL PRIVILEGES_SYMBOL? (
+            ON_SYMBOL aclType? grantIdentifier
+            | COMMA_SYMBOL GRANT_SYMBOL OPTION_SYMBOL
+        ) FROM_SYMBOL userList
+        | PROXY_SYMBOL ON_SYMBOL user FROM_SYMBOL userList
+    ) ({serverVersion >= 80031}? ignoreUnknownUser)?
+;
+
+aclType:
+    TABLE_SYMBOL
+    | FUNCTION_SYMBOL
+    | PROCEDURE_SYMBOL
+;
+
+roleOrPrivilegesList:
+    roleOrPrivilege (COMMA_SYMBOL roleOrPrivilege)*
+;
+
+roleOrPrivilege:
+    (
+        roleIdentifierOrText columnInternalRefList?
+        | roleIdentifierOrText (AT_TEXT_SUFFIX | AT_SIGN_SYMBOL textOrIdentifier)
+    )
+    | (SELECT_SYMBOL | INSERT_SYMBOL | UPDATE_SYMBOL | REFERENCES_SYMBOL) columnInternalRefList?
+    | (
+        DELETE_SYMBOL
+        | USAGE_SYMBOL
+        | INDEX_SYMBOL
+        | DROP_SYMBOL
+        | EXECUTE_SYMBOL
+        | RELOAD_SYMBOL
+        | SHUTDOWN_SYMBOL
+        | PROCESS_SYMBOL
+        | FILE_SYMBOL
+        | PROXY_SYMBOL
+        | SUPER_SYMBOL
+        | EVENT_SYMBOL
+        | TRIGGER_SYMBOL
+    )
+    | GRANT_SYMBOL OPTION_SYMBOL
+    | SHOW_SYMBOL DATABASES_SYMBOL
+    | CREATE_SYMBOL (
+        TEMPORARY_SYMBOL object = TABLES_SYMBOL
+        | object = (ROUTINE_SYMBOL | TABLESPACE_SYMBOL | USER_SYMBOL | VIEW_SYMBOL)
+    )?
+    | LOCK_SYMBOL TABLES_SYMBOL
+    | REPLICATION_SYMBOL (CLIENT_SYMBOL | replica)
+    | SHOW_SYMBOL VIEW_SYMBOL
+    | ALTER_SYMBOL ROUTINE_SYMBOL?
+    | (CREATE_SYMBOL | DROP_SYMBOL) ROLE_SYMBOL
+;
+
+grantIdentifier:
+    MULT_OPERATOR (DOT_SYMBOL MULT_OPERATOR)?
+    | schemaRef (DOT_SYMBOL MULT_OPERATOR)?
+    | tableRef
+    | {serverVersion >= 80017}? schemaRef DOT_SYMBOL tableRef
+;
+
+requireList:
+    requireListElement (AND_SYMBOL? requireListElement)*
+;
+
+requireListElement:
+    element = CIPHER_SYMBOL textString
+    | element = ISSUER_SYMBOL textString
+    | element = SUBJECT_SYMBOL textString
+;
+
+grantOption:
+    option = GRANT_SYMBOL OPTION_SYMBOL
+    | {serverVersion < 80011}? (
+        option = MAX_QUERIES_PER_HOUR_SYMBOL ulong_number
+        | option = MAX_UPDATES_PER_HOUR_SYMBOL ulong_number
+        | option = MAX_CONNECTIONS_PER_HOUR_SYMBOL ulong_number
+        | option = MAX_USER_CONNECTIONS_SYMBOL ulong_number
+    )
+;
+
+setRoleStatement:
+    SET_SYMBOL ROLE_SYMBOL roleList
+    | SET_SYMBOL ROLE_SYMBOL (NONE_SYMBOL | DEFAULT_SYMBOL)
+    | SET_SYMBOL DEFAULT_SYMBOL ROLE_SYMBOL (roleList | NONE_SYMBOL | ALL_SYMBOL) TO_SYMBOL roleList
+    | SET_SYMBOL ROLE_SYMBOL ALL_SYMBOL (EXCEPT_SYMBOL roleList)?
+;
+
+roleList:
+    role (COMMA_SYMBOL role)*
+;
+
+role:
+    roleIdentifierOrText userVariable?
+;
+
+//----------------------------------------------------------------------------------------------------------------------
+
+tableAdministrationStatement:
+    type = ANALYZE_SYMBOL noWriteToBinLog? TABLE_SYMBOL tableRefList histogram?
+    | type = CHECK_SYMBOL TABLE_SYMBOL tableRefList checkOption*
+    | type = CHECKSUM_SYMBOL TABLE_SYMBOL tableRefList (
+        QUICK_SYMBOL
+        | EXTENDED_SYMBOL
+    )?
+    | type = OPTIMIZE_SYMBOL noWriteToBinLog? TABLE_SYMBOL tableRefList
+    | type = REPAIR_SYMBOL noWriteToBinLog? TABLE_SYMBOL tableRefList repairType*
+;
+
+histogramAutoUpdate:
+    {serverVersion >= 80200}? (MANUAL_SYMBOL | AUTO_SYMBOL) UPDATE_SYMBOL
+;
+
+histogramUpdateParam:
+    histogramNumBuckets? histogramAutoUpdate?
+    | {serverVersion >= 80031}? USING_SYMBOL DATA_SYMBOL textStringLiteral
+;
+
+histogramNumBuckets:
+    {serverVersion >= 80200}? WITH_SYMBOL INT_NUMBER BUCKETS_SYMBOL
+;
+
+histogram:
+    UPDATE_SYMBOL HISTOGRAM_SYMBOL ON_SYMBOL identifierList histogramUpdateParam
+    | DROP_SYMBOL HISTOGRAM_SYMBOL ON_SYMBOL identifierList
+;
+
+checkOption:
+    FOR_SYMBOL UPGRADE_SYMBOL
+    | (QUICK_SYMBOL | FAST_SYMBOL | MEDIUM_SYMBOL | EXTENDED_SYMBOL | CHANGED_SYMBOL)
+;
+
+repairType:
+    QUICK_SYMBOL
+    | EXTENDED_SYMBOL
+    | USE_FRM_SYMBOL
+;
+
+//----------------------------------------------------------------------------------------------------------------------
+
+uninstallStatement:
+    UNINSTALL_SYMBOL (
+        PLUGIN_SYMBOL pluginRef
+        | COMPONENT_SYMBOL componentRef (COMMA_SYMBOL componentRef)*
+    )
+;
+
+installStatement:
+    INSTALL_SYMBOL (
+        PLUGIN_SYMBOL identifier SONAME_SYMBOL textStringLiteral
+        | COMPONENT_SYMBOL textStringLiteralList installSetValueList?
+    )
+;
+
+installOptionType:
+    GLOBAL_SYMBOL
+    | PERSIST_SYMBOL
+;
+
+installSetRvalue:
+    expr
+    | ON_SYMBOL
+;
+
+installSetValue:
+    installOptionType lvalueVariable equal installSetRvalue
+;
+
+installSetValueList:
+    {serverVersion >= 80032}? SET_SYMBOL installSetValue (
+        COMMA_SYMBOL installSetValue
+    )*
+;
+
+//----------------------------------------------------------------------------------------------------------------------
+
+setStatement:
+    SET_SYMBOL startOptionValueList
+;
+
+startOptionValueList:
+    optionValueNoOptionType optionValueListContinued
+    | TRANSACTION_SYMBOL transactionCharacteristics
+    | optionType startOptionValueListFollowingOptionType
+    | PASSWORD_SYMBOL (FOR_SYMBOL user)? equal (
+        textString replacePassword? retainCurrentPassword?
+        | textString replacePassword? retainCurrentPassword?
+        | {serverVersion < 80014}? PASSWORD_SYMBOL OPEN_PAR_SYMBOL textString CLOSE_PAR_SYMBOL
+    )
+    | {serverVersion >= 80018}? PASSWORD_SYMBOL (FOR_SYMBOL user)? TO_SYMBOL RANDOM_SYMBOL replacePassword? retainCurrentPassword?
+;
+
+transactionCharacteristics:
+    transactionAccessMode isolationLevel?
+    | isolationLevel (COMMA_SYMBOL transactionAccessMode)?
+;
+
+transactionAccessMode:
+    READ_SYMBOL (WRITE_SYMBOL | ONLY_SYMBOL)
+;
+
+isolationLevel:
+    ISOLATION_SYMBOL LEVEL_SYMBOL (
+        REPEATABLE_SYMBOL READ_SYMBOL
+        | READ_SYMBOL (COMMITTED_SYMBOL | UNCOMMITTED_SYMBOL)
+        | SERIALIZABLE_SYMBOL
+    )
+;
+
+optionValueListContinued:
+    (COMMA_SYMBOL optionValue)*
+;
+
+optionValueNoOptionType:
+    lvalueVariable equal setExprOrDefault
+    | charsetClause
+    | userVariable equal expr
+    | AT_AT_SIGN_SYMBOL setVarIdentType? lvalueVariable equal setExprOrDefault
+    | NAMES_SYMBOL (
+        equal expr
+        | charsetName collate?
+        | {serverVersion >= 80011}? DEFAULT_SYMBOL
+    )
+;
+
+optionValue:
+    optionType lvalueVariable equal setExprOrDefault
+    | optionValueNoOptionType
+;
+
+setSystemVariable:
+    AT_AT_SIGN_SYMBOL setVarIdentType? lvalueVariable
+;
+
+startOptionValueListFollowingOptionType:
+    optionValueFollowingOptionType optionValueListContinued
+    | TRANSACTION_SYMBOL transactionCharacteristics
+;
+
+optionValueFollowingOptionType:
+    lvalueVariable equal setExprOrDefault
+;
+
+setExprOrDefault:
+    expr
+    | DEFAULT_SYMBOL
+    | ON_SYMBOL
+    | ALL_SYMBOL
+    | BINARY_SYMBOL
+    | ROW_SYMBOL
+    | SYSTEM_SYMBOL
+;
+
+//----------------------------------------------------------------------------------------------------------------------
+
+showDatabasesStatement:
+    SHOW_SYMBOL DATABASES_SYMBOL likeOrWhere?
+;
+
+showTablesStatement:
+    SHOW_SYMBOL showCommandType? value = TABLES_SYMBOL inDb? likeOrWhere?
+;
+
+showTriggersStatement:
+    SHOW_SYMBOL FULL_SYMBOL? TRIGGERS_SYMBOL inDb? likeOrWhere?
+;
+
+showEventsStatement:
+    SHOW_SYMBOL EVENTS_SYMBOL inDb? likeOrWhere?
+;
+
+showTableStatusStatement:
+    SHOW_SYMBOL TABLE_SYMBOL STATUS_SYMBOL inDb? likeOrWhere?
+;
+
+showOpenTablesStatement:
+    SHOW_SYMBOL OPEN_SYMBOL TABLES_SYMBOL inDb? likeOrWhere?
+;
+
+showParseTreeStatement:
+    {serverVersion >= 80100}? SHOW_SYMBOL PARSE_TREE_SYMBOL simpleStatement
+;
+
+showPluginsStatement:
+    SHOW_SYMBOL PLUGINS_SYMBOL
+;
+
+showEngineLogsStatement:
+    SHOW_SYMBOL ENGINE_SYMBOL engineOrAll LOGS_SYMBOL
+;
+
+showEngineMutexStatement:
+    SHOW_SYMBOL ENGINE_SYMBOL engineOrAll MUTEX_SYMBOL
+;
+
+showEngineStatusStatement:
+    SHOW_SYMBOL ENGINE_SYMBOL engineOrAll STATUS_SYMBOL
+;
+
+showColumnsStatement:
+    SHOW_SYMBOL showCommandType? COLUMNS_SYMBOL (FROM_SYMBOL | IN_SYMBOL) tableRef inDb? likeOrWhere?
+;
+
+showBinaryLogsStatement:
+    SHOW_SYMBOL (BINARY_SYMBOL | MASTER_SYMBOL) value = LOGS_SYMBOL
+;
+
+showBinaryLogStatusStatement:
+    SHOW_SYMBOL BINARY_SYMBOL LOG_SYMBOL STATUS_SYMBOL
+;
+
+showReplicasStatement:
+    SHOW_SYMBOL (replica HOSTS_SYMBOL | REPLICAS_SYMBOL)
+;
+
+showBinlogEventsStatement:
+    SHOW_SYMBOL BINLOG_SYMBOL EVENTS_SYMBOL (IN_SYMBOL textString)? (
+        FROM_SYMBOL ulonglongNumber
+    )? limitClause? channel?
+;
+
+showRelaylogEventsStatement:
+    SHOW_SYMBOL RELAYLOG_SYMBOL EVENTS_SYMBOL (IN_SYMBOL textString)? (
+        FROM_SYMBOL ulonglongNumber
+    )? limitClause? channel?
+;
+
+showKeysStatement:
+    SHOW_SYMBOL EXTENDED_SYMBOL? (INDEX_SYMBOL | INDEXES_SYMBOL | KEYS_SYMBOL) fromOrIn tableRef inDb? whereClause?
+;
+
+showEnginesStatement:
+    SHOW_SYMBOL STORAGE_SYMBOL? value = ENGINES_SYMBOL
+;
+
+showCountWarningsStatement:
+    SHOW_SYMBOL COUNT_SYMBOL OPEN_PAR_SYMBOL MULT_OPERATOR CLOSE_PAR_SYMBOL WARNINGS_SYMBOL
+;
+
+showCountErrorsStatement:
+    SHOW_SYMBOL COUNT_SYMBOL OPEN_PAR_SYMBOL MULT_OPERATOR CLOSE_PAR_SYMBOL ERRORS_SYMBOL
+;
+
+showWarningsStatement:
+    SHOW_SYMBOL WARNINGS_SYMBOL limitClause?
+;
+
+showErrorsStatement:
+    SHOW_SYMBOL ERRORS_SYMBOL limitClause?
+;
+
+showProfilesStatement:
+    SHOW_SYMBOL PROFILES_SYMBOL
+;
+
+showProfileStatement:
+    SHOW_SYMBOL PROFILE_SYMBOL profileDefinitions? (
+        FOR_SYMBOL QUERY_SYMBOL INT_NUMBER
+    )? limitClause?
+;
+
+showStatusStatement:
+    SHOW_SYMBOL optionType? STATUS_SYMBOL likeOrWhere?
+;
+
+showProcessListStatement:
+    SHOW_SYMBOL FULL_SYMBOL? PROCESSLIST_SYMBOL
+;
+
+showVariablesStatement:
+    SHOW_SYMBOL optionType? VARIABLES_SYMBOL likeOrWhere?
+;
+
+showCharacterSetStatement:
+    SHOW_SYMBOL charset likeOrWhere?
+;
+
+showCollationStatement:
+    SHOW_SYMBOL COLLATION_SYMBOL likeOrWhere?
+;
+
+showPrivilegesStatement:
+    SHOW_SYMBOL PRIVILEGES_SYMBOL
+;
+
+showGrantsStatement:
+    SHOW_SYMBOL GRANTS_SYMBOL (FOR_SYMBOL user (USING_SYMBOL userList)?)?
+;
+
+showCreateDatabaseStatement:
+    SHOW_SYMBOL CREATE_SYMBOL DATABASE_SYMBOL ifNotExists? schemaRef
+;
+
+showCreateTableStatement:
+    SHOW_SYMBOL CREATE_SYMBOL TABLE_SYMBOL tableRef
+;
+
+showCreateViewStatement:
+    SHOW_SYMBOL CREATE_SYMBOL VIEW_SYMBOL viewRef
+;
+
+showMasterStatusStatement:
+    SHOW_SYMBOL MASTER_SYMBOL STATUS_SYMBOL
+;
+
+showReplicaStatusStatement:
+    SHOW_SYMBOL replica STATUS_SYMBOL channel?
+;
+
+showCreateProcedureStatement:
+    SHOW_SYMBOL CREATE_SYMBOL PROCEDURE_SYMBOL procedureRef
+;
+
+showCreateFunctionStatement:
+    SHOW_SYMBOL CREATE_SYMBOL FUNCTION_SYMBOL functionRef
+;
+
+showCreateTriggerStatement:
+    SHOW_SYMBOL CREATE_SYMBOL TRIGGER_SYMBOL triggerRef
+;
+
+showCreateProcedureStatusStatement:
+    SHOW_SYMBOL CREATE_SYMBOL PROCEDURE_SYMBOL STATUS_SYMBOL likeOrWhere?
+;
+
+showCreateFunctionStatusStatement:
+    SHOW_SYMBOL CREATE_SYMBOL FUNCTION_SYMBOL STATUS_SYMBOL likeOrWhere?
+;
+
+showCreateProcedureCodeStatement:
+    SHOW_SYMBOL CREATE_SYMBOL PROCEDURE_SYMBOL CODE_SYMBOL procedureRef
+;
+
+showCreateFunctionCodeStatement:
+    SHOW_SYMBOL CREATE_SYMBOL FUNCTION_SYMBOL CODE_SYMBOL functionRef
+;
+
+showCreateEventStatement:
+    SHOW_SYMBOL CREATE_SYMBOL EVENT_SYMBOL eventRef
+;
+
+showCreateUserStatement:
+    SHOW_SYMBOL CREATE_SYMBOL USER_SYMBOL user
+;
+
+showCommandType:
+    FULL_SYMBOL
+    | EXTENDED_SYMBOL FULL_SYMBOL?
+;
+
+engineOrAll:
+    engineRef
+    | ALL_SYMBOL
+;
+
+fromOrIn:
+    FROM_SYMBOL
+    | IN_SYMBOL
+;
+
+inDb:
+    fromOrIn identifier
+;
+
+profileDefinitions:
+    profileDefinition (COMMA_SYMBOL profileDefinition)*
+;
+
+profileDefinition:
+    BLOCK_SYMBOL IO_SYMBOL
+    | CONTEXT_SYMBOL SWITCHES_SYMBOL
+    | PAGE_SYMBOL FAULTS_SYMBOL
+    | (
+        ALL_SYMBOL
+        | CPU_SYMBOL
+        | IPC_SYMBOL
+        | MEMORY_SYMBOL
+        | SOURCE_SYMBOL
+        | SWAPS_SYMBOL
+    )
+;
+
+//----------------------------------------------------------------------------------------------------------------------
+
+otherAdministrativeStatement:
+    type = BINLOG_SYMBOL textLiteral
+    | type = CACHE_SYMBOL INDEX_SYMBOL keyCacheListOrParts IN_SYMBOL (
+        identifier
+        | DEFAULT_SYMBOL
+    )
+    | type = FLUSH_SYMBOL noWriteToBinLog? (
+        flushTables
+        | flushOption (COMMA_SYMBOL flushOption)*
+    )
+    | type = KILL_SYMBOL (CONNECTION_SYMBOL | QUERY_SYMBOL)? expr
+    | type = LOAD_SYMBOL INDEX_SYMBOL INTO_SYMBOL CACHE_SYMBOL preloadTail
+    | type = SHUTDOWN_SYMBOL
+;
+
+keyCacheListOrParts:
+    keyCacheList
+    | assignToKeycachePartition
+;
+
+keyCacheList:
+    assignToKeycache (COMMA_SYMBOL assignToKeycache)*
+;
+
+assignToKeycache:
+    tableRef cacheKeyList?
+;
+
+assignToKeycachePartition:
+    tableRef PARTITION_SYMBOL OPEN_PAR_SYMBOL allOrPartitionNameList CLOSE_PAR_SYMBOL cacheKeyList?
+;
+
+cacheKeyList:
+    keyOrIndex OPEN_PAR_SYMBOL keyUsageList? CLOSE_PAR_SYMBOL
+;
+
+keyUsageElement:
+    identifier
+    | PRIMARY_SYMBOL
+;
+
+keyUsageList:
+    keyUsageElement (COMMA_SYMBOL keyUsageElement)*
+;
+
+flushOption:
+    option = (
+        HOSTS_SYMBOL
+        | PRIVILEGES_SYMBOL
+        | STATUS_SYMBOL
+        | USER_RESOURCES_SYMBOL
+    )
+    | logType? option = LOGS_SYMBOL
+    | option = RELAY_SYMBOL LOGS_SYMBOL channel?
+    | option = OPTIMIZER_COSTS_SYMBOL
+;
+
+logType:
+    BINARY_SYMBOL
+    | ENGINE_SYMBOL
+    | ERROR_SYMBOL
+    | GENERAL_SYMBOL
+    | SLOW_SYMBOL
+;
+
+flushTables:
+    (TABLES_SYMBOL | TABLE_SYMBOL) (
+        WITH_SYMBOL READ_SYMBOL LOCK_SYMBOL
+        | identifierList flushTablesOptions?
+    )?
+;
+
+flushTablesOptions:
+    FOR_SYMBOL EXPORT_SYMBOL
+    | WITH_SYMBOL READ_SYMBOL LOCK_SYMBOL
+;
+
+preloadTail:
+    tableRef adminPartition cacheKeyList? (IGNORE_SYMBOL LEAVES_SYMBOL)?
+    | preloadList
+;
+
+preloadList:
+    preloadKeys (COMMA_SYMBOL preloadKeys)*
+;
+
+preloadKeys:
+    tableRef cacheKeyList? (IGNORE_SYMBOL LEAVES_SYMBOL)?
+;
+
+adminPartition:
+    PARTITION_SYMBOL OPEN_PAR_SYMBOL allOrPartitionNameList CLOSE_PAR_SYMBOL
+;
+
+//----------------------------------------------------------------------------------------------------------------------
+
+resourceGroupManagement:
+    createResourceGroup
+    | alterResourceGroup
+    | setResourceGroup
+    | dropResourceGroup
+;
+
+createResourceGroup:
+    CREATE_SYMBOL RESOURCE_SYMBOL GROUP_SYMBOL identifier TYPE_SYMBOL equal? (
+        USER_SYMBOL
+        | SYSTEM_SYMBOL
+    ) resourceGroupVcpuList? resourceGroupPriority? resourceGroupEnableDisable?
+;
+
+resourceGroupVcpuList:
+    VCPU_SYMBOL equal? vcpuNumOrRange (COMMA_SYMBOL? vcpuNumOrRange)*
+;
+
+vcpuNumOrRange:
+    INT_NUMBER (MINUS_OPERATOR INT_NUMBER)?
+;
+
+resourceGroupPriority:
+    THREAD_PRIORITY_SYMBOL equal? INT_NUMBER
+;
+
+resourceGroupEnableDisable:
+    ENABLE_SYMBOL
+    | DISABLE_SYMBOL
+;
+
+alterResourceGroup:
+    ALTER_SYMBOL RESOURCE_SYMBOL GROUP_SYMBOL resourceGroupRef resourceGroupVcpuList? resourceGroupPriority?
+        resourceGroupEnableDisable? FORCE_SYMBOL?
+;
+
+setResourceGroup:
+    SET_SYMBOL RESOURCE_SYMBOL GROUP_SYMBOL identifier (FOR_SYMBOL threadIdList)?
+;
+
+threadIdList:
+    real_ulong_number (COMMA_SYMBOL? real_ulong_number)*
+;
+
+dropResourceGroup:
+    DROP_SYMBOL RESOURCE_SYMBOL GROUP_SYMBOL resourceGroupRef FORCE_SYMBOL?
+;
+
+//----------------------------------------------------------------------------------------------------------------------
+
+utilityStatement:
+    describeStatement
+    | explainStatement
+    | helpCommand
+    | useCommand
+    | {serverVersion >= 80011}? restartServer
+;
+
+describeStatement:
+    (EXPLAIN_SYMBOL | DESCRIBE_SYMBOL | DESC_SYMBOL) tableRef (
+        textString
+        | columnRef
+    )?
+;
+
+explainStatement:
+    (EXPLAIN_SYMBOL | DESCRIBE_SYMBOL | DESC_SYMBOL) explainOptions? (
+        {serverVersion >= 80032}? FOR_SYMBOL DATABASE_SYMBOL textOrIdentifier
+    )? explainableStatement
+;
+
+explainOptions:
+    FORMAT_SYMBOL EQUAL_OPERATOR textOrIdentifier (
+        {serverVersion >= 80032}? explainInto
+    )?
+    | {serverVersion < 80012}? EXTENDED_SYMBOL
+    | {serverVersion >= 80018}? ANALYZE_SYMBOL
+    | {serverVersion >= 80019}? ANALYZE_SYMBOL FORMAT_SYMBOL EQUAL_OPERATOR textOrIdentifier
+;
+
+explainableStatement:
+    selectStatement
+    | deleteStatement
+    | insertStatement
+    | replaceStatement
+    | updateStatement
+    | FOR_SYMBOL CONNECTION_SYMBOL real_ulong_number
+;
+
+explainInto:
+    INTO_SYMBOL AT_SIGN_SYMBOL textOrIdentifier
+;
+
+helpCommand:
+    HELP_SYMBOL textOrIdentifier
+;
+
+useCommand:
+    USE_SYMBOL schemaRef
+;
+
+restartServer:
+    RESTART_SYMBOL
+;
+
+//----------------- Expression support ---------------------------------------------------------------------------------
+
+expr:
+    boolPri (IS_SYMBOL notRule? type = (TRUE_SYMBOL | FALSE_SYMBOL | UNKNOWN_SYMBOL))? # exprIs
+    | NOT_SYMBOL expr                                                                  # exprNot
+    | expr op = (AND_SYMBOL | LOGICAL_AND_OPERATOR) expr                               # exprAnd
+    | expr XOR_SYMBOL expr                                                             # exprXor
+    | expr op = (OR_SYMBOL | LOGICAL_OR_OPERATOR) expr                                 # exprOr
+;
+
+boolPri:
+    predicate                                           # primaryExprPredicate
+    | boolPri IS_SYMBOL notRule? NULL_SYMBOL            # primaryExprIsNull
+    | boolPri compOp predicate                          # primaryExprCompare
+    | boolPri compOp (ALL_SYMBOL | ANY_SYMBOL) subquery # primaryExprAllAny
+;
+
+compOp:
+    EQUAL_OPERATOR
+    | NULL_SAFE_EQUAL_OPERATOR
+    | GREATER_OR_EQUAL_OPERATOR
+    | GREATER_THAN_OPERATOR
+    | LESS_OR_EQUAL_OPERATOR
+    | LESS_THAN_OPERATOR
+    | NOT_EQUAL_OPERATOR
+;
+
+predicate:
+    bitExpr (
+        notRule? predicateOperations
+        | {serverVersion >= 80017}? MEMBER_SYMBOL OF_SYMBOL? simpleExprWithParentheses
+        | SOUNDS_SYMBOL LIKE_SYMBOL bitExpr
+    )?
+;
+
+predicateOperations:
+    IN_SYMBOL (subquery | OPEN_PAR_SYMBOL exprList CLOSE_PAR_SYMBOL) # predicateExprIn
+    | BETWEEN_SYMBOL bitExpr AND_SYMBOL predicate                    # predicateExprBetween
+    | LIKE_SYMBOL simpleExpr (ESCAPE_SYMBOL simpleExpr)?             # predicateExprLike
+    | REGEXP_SYMBOL bitExpr                                          # predicateExprRegex
+;
+
+bitExpr:
+    simpleExpr
+    | bitExpr op = BITWISE_XOR_OPERATOR bitExpr
+    | bitExpr op = (
+        MULT_OPERATOR
+        | DIV_OPERATOR
+        | MOD_OPERATOR
+        | DIV_SYMBOL
+        | MOD_SYMBOL
+    ) bitExpr
+    | bitExpr op = (PLUS_OPERATOR | MINUS_OPERATOR) bitExpr
+    | bitExpr op = (PLUS_OPERATOR | MINUS_OPERATOR) INTERVAL_SYMBOL expr interval
+    | bitExpr op = (SHIFT_LEFT_OPERATOR | SHIFT_RIGHT_OPERATOR) bitExpr
+    | bitExpr op = BITWISE_AND_OPERATOR bitExpr
+    | bitExpr op = BITWISE_OR_OPERATOR bitExpr
+;
+
+// $antlr-format groupedAlignments off
+simpleExpr:
+    columnRef jsonOperator?                                                                                     # simpleExprColumnRef
+    | runtimeFunctionCall                                                                                       # simpleExprRuntimeFunction
+    | functionCall                                                                                              # simpleExprFunction
+    | simpleExpr COLLATE_SYMBOL textOrIdentifier                                                                # simpleExprCollate
+    | literalOrNull                                                                                             # simpleExprLiteral
+    | PARAM_MARKER                                                                                              # simpleExprParamMarker
+    | rvalueSystemOrUserVariable                                                                                # simpleExpressionRValue
+    | inExpressionUserVariableAssignment                                                                        # simpleExprUserVariableAssignment
+    | sumExpr                                                                                                   # simpleExprSum
+    | groupingOperation                                                                                         # simpleExprGroupingOperation
+    | windowFunctionCall                                                                                        # simpleExprWindowingFunction
+    | simpleExpr CONCAT_PIPES_SYMBOL simpleExpr                                                                 # simpleExprConcat
+    | op = (PLUS_OPERATOR | MINUS_OPERATOR | BITWISE_NOT_OPERATOR) simpleExpr                                   # simpleExprUnary
+    | not2Rule simpleExpr                                                                                       # simpleExprNot
+    | ROW_SYMBOL? OPEN_PAR_SYMBOL exprList CLOSE_PAR_SYMBOL                                                     # simpleExprList
+    | EXISTS_SYMBOL? subquery                                                                                   # simpleExprSubQuery
+    | OPEN_CURLY_SYMBOL identifier expr CLOSE_CURLY_SYMBOL                                                      # simpleExprOdbc
+    | MATCH_SYMBOL identListArg AGAINST_SYMBOL OPEN_PAR_SYMBOL bitExpr fulltextOptions? CLOSE_PAR_SYMBOL        # simpleExprMatch
+    | BINARY_SYMBOL simpleExpr                                                                                  # simpleExprBinary
+    | CAST_SYMBOL OPEN_PAR_SYMBOL expr (AT_SYMBOL LOCAL_SYMBOL)? AS_SYMBOL castType arrayCast? CLOSE_PAR_SYMBOL # simpleExprCast
+    | CAST_SYMBOL OPEN_PAR_SYMBOL expr AT_SYMBOL TIME_SYMBOL ZONE_SYMBOL INTERVAL_SYMBOL? textStringLiteral AS_SYMBOL
+        DATETIME_SYMBOL typeDatetimePrecision CLOSE_PAR_SYMBOL                                                  # simpleExprCastTime
+    | CASE_SYMBOL expr? (whenExpression thenExpression)+ elseExpression? END_SYMBOL                             # simpleExprCase
+    | CONVERT_SYMBOL OPEN_PAR_SYMBOL expr COMMA_SYMBOL castType CLOSE_PAR_SYMBOL                                # simpleExprConvert
+    | CONVERT_SYMBOL OPEN_PAR_SYMBOL expr USING_SYMBOL charsetName CLOSE_PAR_SYMBOL                             # simpleExprConvertUsing
+    | DEFAULT_SYMBOL OPEN_PAR_SYMBOL simpleIdentifier CLOSE_PAR_SYMBOL                                          # simpleExprDefault
+    | VALUES_SYMBOL OPEN_PAR_SYMBOL simpleIdentifier CLOSE_PAR_SYMBOL                                           # simpleExprValues
+    | INTERVAL_SYMBOL expr interval PLUS_OPERATOR expr                                                          # simpleExprInterval
+;
+
+// $antlr-format groupedAlignments on
+
+arrayCast:
+    {serverVersion >= 80017}? ARRAY_SYMBOL
+;
+
+jsonOperator:
+    JSON_SEPARATOR_SYMBOL textStringLiteral
+    | JSON_UNQUOTED_SEPARATOR_SYMBOL textStringLiteral
+;
+
+sumExpr:
+    name = AVG_SYMBOL OPEN_PAR_SYMBOL DISTINCT_SYMBOL? inSumExpr CLOSE_PAR_SYMBOL windowingClause?
+    | name = (BIT_AND_SYMBOL | BIT_OR_SYMBOL | BIT_XOR_SYMBOL) OPEN_PAR_SYMBOL inSumExpr CLOSE_PAR_SYMBOL windowingClause?
+    | jsonFunction
+    | name = ST_COLLECT_SYMBOL OPEN_PAR_SYMBOL DISTINCT_SYMBOL? inSumExpr CLOSE_PAR_SYMBOL windowingClause?
+    | name = COUNT_SYMBOL OPEN_PAR_SYMBOL (
+        ALL_SYMBOL? MULT_OPERATOR
+        | inSumExpr
+        | DISTINCT_SYMBOL exprList
+    ) CLOSE_PAR_SYMBOL windowingClause?
+    | name = (MIN_SYMBOL | MAX_SYMBOL) OPEN_PAR_SYMBOL DISTINCT_SYMBOL? inSumExpr CLOSE_PAR_SYMBOL windowingClause?
+    | name = (
+        STD_SYMBOL
+        | VARIANCE_SYMBOL
+        | STDDEV_SAMP_SYMBOL
+        | VAR_SAMP_SYMBOL
+        | SUM_SYMBOL
+    ) OPEN_PAR_SYMBOL inSumExpr CLOSE_PAR_SYMBOL windowingClause?
+    | name = SUM_SYMBOL OPEN_PAR_SYMBOL DISTINCT_SYMBOL inSumExpr CLOSE_PAR_SYMBOL windowingClause?
+    | name = GROUP_CONCAT_SYMBOL OPEN_PAR_SYMBOL DISTINCT_SYMBOL? exprList orderClause? (
+        SEPARATOR_SYMBOL textString
+    )? CLOSE_PAR_SYMBOL windowingClause?
+;
+
+groupingOperation:
+    GROUPING_SYMBOL OPEN_PAR_SYMBOL exprList CLOSE_PAR_SYMBOL
+;
+
+windowFunctionCall:
+    (
+        ROW_NUMBER_SYMBOL
+        | RANK_SYMBOL
+        | DENSE_RANK_SYMBOL
+        | CUME_DIST_SYMBOL
+        | PERCENT_RANK_SYMBOL
+    ) parentheses windowingClause
+    | NTILE_SYMBOL (
+        OPEN_PAR_SYMBOL stableInteger CLOSE_PAR_SYMBOL
+        | {serverVersion < 80024}? simpleExprWithParentheses
+    ) windowingClause
+    | (LEAD_SYMBOL | LAG_SYMBOL) OPEN_PAR_SYMBOL expr leadLagInfo? CLOSE_PAR_SYMBOL nullTreatment? windowingClause
+    | (FIRST_VALUE_SYMBOL | LAST_VALUE_SYMBOL) exprWithParentheses nullTreatment? windowingClause
+    | NTH_VALUE_SYMBOL OPEN_PAR_SYMBOL expr COMMA_SYMBOL simpleExpr CLOSE_PAR_SYMBOL (
+        FROM_SYMBOL (FIRST_SYMBOL | LAST_SYMBOL)
+    )? nullTreatment? windowingClause
+;
+
+samplingMethod:
+    SYSTEM_SYMBOL
+    | BENROULLI_SYMBOL
+;
+
+samplingPercentage:
+    ulonglongNumber
+    | AT_SIGN_SYMBOL textOrIdentifier
+    | PARAM_MARKER
+;
+
+tablesampleClause:
+    {serverVersion >= 80200}? TABLESAMPLE_SYMBOL samplingMethod OPEN_PAR_SYMBOL samplingPercentage CLOSE_PAR_SYMBOL
+;
+
+windowingClause:
+    OVER_SYMBOL (windowName | windowSpec)
+;
+
+leadLagInfo:
+    COMMA_SYMBOL (
+        ulonglongNumber
+        | PARAM_MARKER
+        | {serverVersion >= 80024}? stableInteger
+    ) (COMMA_SYMBOL expr)?
+;
+
+// The stable_integer nonterminal symbol is not really constant, but constant for the duration of an execution.
+stableInteger:
+    int64Literal
+    | paramOrVar
+;
+
+paramOrVar:
+    PARAM_MARKER
+    | identifier
+    | AT_SIGN_SYMBOL textOrIdentifier
+;
+
+nullTreatment:
+    (RESPECT_SYMBOL | IGNORE_SYMBOL) NULLS_SYMBOL
+;
+
+jsonFunction:
+    JSON_ARRAYAGG_SYMBOL OPEN_PAR_SYMBOL inSumExpr CLOSE_PAR_SYMBOL windowingClause?
+    | JSON_OBJECTAGG_SYMBOL OPEN_PAR_SYMBOL inSumExpr COMMA_SYMBOL inSumExpr CLOSE_PAR_SYMBOL windowingClause?
+;
+
+inSumExpr:
+    ALL_SYMBOL? expr
+;
+
+identListArg:
+    identList
+    | OPEN_PAR_SYMBOL identList CLOSE_PAR_SYMBOL
+;
+
+identList:
+    simpleIdentifier (COMMA_SYMBOL simpleIdentifier)*
+;
+
+fulltextOptions:
+    IN_SYMBOL BOOLEAN_SYMBOL MODE_SYMBOL
+    | IN_SYMBOL NATURAL_SYMBOL LANGUAGE_SYMBOL MODE_SYMBOL (
+        WITH_SYMBOL QUERY_SYMBOL EXPANSION_SYMBOL
+    )?
+    | WITH_SYMBOL QUERY_SYMBOL EXPANSION_SYMBOL
+;
+
+// function_call_keyword and function_call_nonkeyword in sql_yacc.yy.
+runtimeFunctionCall:
+    // Function names that are keywords.
+    CHAR_SYMBOL OPEN_PAR_SYMBOL exprList (USING_SYMBOL charsetName)? CLOSE_PAR_SYMBOL
+    | CURRENT_USER_SYMBOL parentheses?
+    | DATE_SYMBOL exprWithParentheses
+    | DAY_SYMBOL exprWithParentheses
+    | HOUR_SYMBOL exprWithParentheses
+    | INSERT_SYMBOL OPEN_PAR_SYMBOL expr COMMA_SYMBOL expr COMMA_SYMBOL expr COMMA_SYMBOL expr CLOSE_PAR_SYMBOL
+    | INTERVAL_SYMBOL OPEN_PAR_SYMBOL expr (COMMA_SYMBOL expr)+ CLOSE_PAR_SYMBOL
+    | JSON_VALUE_SYMBOL OPEN_PAR_SYMBOL simpleExpr COMMA_SYMBOL textLiteral returningType? onEmptyOrError CLOSE_PAR_SYMBOL
+    | LEFT_SYMBOL OPEN_PAR_SYMBOL expr COMMA_SYMBOL expr CLOSE_PAR_SYMBOL
+    | MINUTE_SYMBOL exprWithParentheses
+    | MONTH_SYMBOL exprWithParentheses
+    | RIGHT_SYMBOL OPEN_PAR_SYMBOL expr COMMA_SYMBOL expr CLOSE_PAR_SYMBOL
+    | SECOND_SYMBOL exprWithParentheses
+    | TIME_SYMBOL exprWithParentheses
+    | TIMESTAMP_SYMBOL OPEN_PAR_SYMBOL expr (COMMA_SYMBOL expr)? CLOSE_PAR_SYMBOL
+    | trimFunction
+    | userFunction
+    | VALUES_SYMBOL exprWithParentheses
+    | YEAR_SYMBOL exprWithParentheses
+
+    // Function names that are not keywords.
+    | (ADDDATE_SYMBOL | SUBDATE_SYMBOL) OPEN_PAR_SYMBOL expr COMMA_SYMBOL (
+        expr
+        | INTERVAL_SYMBOL expr interval
+    ) CLOSE_PAR_SYMBOL
+    | CURDATE_SYMBOL parentheses?
+    | CURTIME_SYMBOL timeFunctionParameters?
+    | (DATE_ADD_SYMBOL | DATE_SUB_SYMBOL) OPEN_PAR_SYMBOL expr COMMA_SYMBOL INTERVAL_SYMBOL expr interval CLOSE_PAR_SYMBOL
+    | EXTRACT_SYMBOL OPEN_PAR_SYMBOL interval FROM_SYMBOL expr CLOSE_PAR_SYMBOL
+    | GET_FORMAT_SYMBOL OPEN_PAR_SYMBOL dateTimeTtype COMMA_SYMBOL expr CLOSE_PAR_SYMBOL
+    | {serverVersion >= 80032}? LOG_SYMBOL OPEN_PAR_SYMBOL expr (COMMA_SYMBOL expr)? CLOSE_PAR_SYMBOL
+    | NOW_SYMBOL timeFunctionParameters?
+    | POSITION_SYMBOL OPEN_PAR_SYMBOL bitExpr IN_SYMBOL expr CLOSE_PAR_SYMBOL
+    | substringFunction
+    | SYSDATE_SYMBOL timeFunctionParameters?
+    | (TIMESTAMPADD_SYMBOL | TIMESTAMPDIFF_SYMBOL) OPEN_PAR_SYMBOL intervalTimeStamp COMMA_SYMBOL expr COMMA_SYMBOL expr
+        CLOSE_PAR_SYMBOL
+    | UTC_DATE_SYMBOL parentheses?
+    | UTC_TIME_SYMBOL timeFunctionParameters?
+    | UTC_TIMESTAMP_SYMBOL timeFunctionParameters?
+
+    // Function calls with other conflicts.
+    | ASCII_SYMBOL exprWithParentheses
+    | CHARSET_SYMBOL exprWithParentheses
+    | COALESCE_SYMBOL exprListWithParentheses
+    | COLLATION_SYMBOL exprWithParentheses
+    | DATABASE_SYMBOL parentheses
+    | IF_SYMBOL OPEN_PAR_SYMBOL expr COMMA_SYMBOL expr COMMA_SYMBOL expr CLOSE_PAR_SYMBOL
+    | FORMAT_SYMBOL OPEN_PAR_SYMBOL expr COMMA_SYMBOL expr (COMMA_SYMBOL expr)? CLOSE_PAR_SYMBOL
+    | MICROSECOND_SYMBOL exprWithParentheses
+    | MOD_SYMBOL OPEN_PAR_SYMBOL expr COMMA_SYMBOL expr CLOSE_PAR_SYMBOL
+    | {serverVersion < 80011}? PASSWORD_SYMBOL exprWithParentheses
+    | QUARTER_SYMBOL exprWithParentheses
+    | REPEAT_SYMBOL OPEN_PAR_SYMBOL expr COMMA_SYMBOL expr CLOSE_PAR_SYMBOL
+    | REPLACE_SYMBOL OPEN_PAR_SYMBOL expr COMMA_SYMBOL expr COMMA_SYMBOL expr CLOSE_PAR_SYMBOL
+    | REVERSE_SYMBOL exprWithParentheses
+    | ROW_COUNT_SYMBOL parentheses
+    | TRUNCATE_SYMBOL OPEN_PAR_SYMBOL expr COMMA_SYMBOL expr CLOSE_PAR_SYMBOL
+    | WEEK_SYMBOL OPEN_PAR_SYMBOL expr (COMMA_SYMBOL expr)? CLOSE_PAR_SYMBOL
+    | WEIGHT_STRING_SYMBOL OPEN_PAR_SYMBOL expr (
+        (AS_SYMBOL CHAR_SYMBOL wsNumCodepoints)?
+        | AS_SYMBOL BINARY_SYMBOL wsNumCodepoints
+        | COMMA_SYMBOL ulong_number COMMA_SYMBOL ulong_number COMMA_SYMBOL ulong_number
+    ) CLOSE_PAR_SYMBOL
+    | geometryFunction
+;
+
+// JSON_VALUE's optional JSON returning clause.
+returningType:
+    // The default returning type is CHAR(512). (The max length of 512
+    // is chosen so that the returned values are not handled as BLOBs
+    // internally. See CONVERT_IF_BIGGER_TO_BLOB.)
+    RETURNING_SYMBOL castType
+;
+
+geometryFunction:
+    GEOMETRYCOLLECTION_SYMBOL OPEN_PAR_SYMBOL exprList? CLOSE_PAR_SYMBOL
+    | LINESTRING_SYMBOL exprListWithParentheses
+    | MULTILINESTRING_SYMBOL exprListWithParentheses
+    | MULTIPOINT_SYMBOL exprListWithParentheses
+    | MULTIPOLYGON_SYMBOL exprListWithParentheses
+    | POINT_SYMBOL OPEN_PAR_SYMBOL expr COMMA_SYMBOL expr CLOSE_PAR_SYMBOL
+    | POLYGON_SYMBOL exprListWithParentheses
+;
+
+timeFunctionParameters:
+    OPEN_PAR_SYMBOL fractionalPrecision? CLOSE_PAR_SYMBOL
+;
+
+fractionalPrecision:
+    INT_NUMBER
+;
+
+weightStringLevels:
+    LEVEL_SYMBOL (
+        real_ulong_number MINUS_OPERATOR real_ulong_number
+        | weightStringLevelListItem (COMMA_SYMBOL weightStringLevelListItem)*
+    )
+;
+
+weightStringLevelListItem:
+    real_ulong_number ((ASC_SYMBOL | DESC_SYMBOL) REVERSE_SYMBOL? | REVERSE_SYMBOL)?
+;
+
+dateTimeTtype:
+    DATE_SYMBOL
+    | TIME_SYMBOL
+    | DATETIME_SYMBOL
+    | TIMESTAMP_SYMBOL
+;
+
+trimFunction:
+    TRIM_SYMBOL OPEN_PAR_SYMBOL (
+        expr (FROM_SYMBOL expr)?
+        | LEADING_SYMBOL expr? FROM_SYMBOL expr
+        | TRAILING_SYMBOL expr? FROM_SYMBOL expr
+        | BOTH_SYMBOL expr? FROM_SYMBOL expr
+    ) CLOSE_PAR_SYMBOL
+;
+
+substringFunction:
+    SUBSTRING_SYMBOL OPEN_PAR_SYMBOL expr (
+        COMMA_SYMBOL expr (COMMA_SYMBOL expr)?
+        | FROM_SYMBOL expr (FOR_SYMBOL expr)?
+    ) CLOSE_PAR_SYMBOL
+;
+
+functionCall:
+    pureIdentifier OPEN_PAR_SYMBOL udfExprList? CLOSE_PAR_SYMBOL     // For both UDF + other functions.
+    | qualifiedIdentifier OPEN_PAR_SYMBOL exprList? CLOSE_PAR_SYMBOL // Other functions only.
+;
+
+udfExprList:
+    udfExpr (COMMA_SYMBOL udfExpr)*
+;
+
+udfExpr:
+    expr selectAlias?
+;
+
+userVariable:
+    AT_SIGN_SYMBOL textOrIdentifier
+    | AT_TEXT_SUFFIX
+;
+
+inExpressionUserVariableAssignment:
+    userVariable ASSIGN_OPERATOR expr
+;
+
+rvalueSystemOrUserVariable:
+    userVariable
+    | AT_AT_SIGN_SYMBOL rvalueSystemVariableType? rvalueSystemVariable
+;
+
+lvalueVariable: (
+        // Check in semantic phase that the first id is not global/local/session/default.
+        identifier dotIdentifier?
+        | {serverVersion >= 80017}? lValueIdentifier dotIdentifier?
+    )
+    | DEFAULT_SYMBOL dotIdentifier
+;
+
+rvalueSystemVariable:
+    textOrIdentifier dotIdentifier?
+;
+
+whenExpression:
+    WHEN_SYMBOL expr
+;
+
+thenExpression:
+    THEN_SYMBOL expr
+;
+
+elseExpression:
+    ELSE_SYMBOL expr
+;
+
+castType:
+    BINARY_SYMBOL fieldLength?
+    | CHAR_SYMBOL fieldLength? charsetWithOptBinary?
+    | nchar fieldLength?
+    | SIGNED_SYMBOL INT_SYMBOL?
+    | UNSIGNED_SYMBOL INT_SYMBOL?
+    | DATE_SYMBOL
+    | {serverVersion >= 80024}? YEAR_SYMBOL
+    | TIME_SYMBOL typeDatetimePrecision?
+    | DATETIME_SYMBOL typeDatetimePrecision?
+    | DECIMAL_SYMBOL floatOptions?
+    | JSON_SYMBOL
+    | {serverVersion >= 80017}? realType
+    | {serverVersion >= 80017}? FLOAT_SYMBOL standardFloatOptions?
+    | {serverVersion >= 80027}? (
+        POINT_SYMBOL
+        | LINESTRING_SYMBOL
+        | POLYGON_SYMBOL
+        | MULTIPOINT_SYMBOL
+        | MULTILINESTRING_SYMBOL
+        | MULTIPOLYGON_SYMBOL
+        | GEOMETRYCOLLECTION_SYMBOL
+    )
+;
+
+exprList:
+    expr (COMMA_SYMBOL expr)*
+;
+
+charset:
+    CHAR_SYMBOL SET_SYMBOL
+    | CHARSET_SYMBOL
+;
+
+notRule:
+    NOT_SYMBOL
+    | NOT2_SYMBOL // A NOT with a different (higher) operator precedence.
+;
+
+not2Rule:
+    LOGICAL_NOT_OPERATOR
+    | NOT2_SYMBOL
+;
+
+// None of the microsecond variants can be used in schedules (e.g. events).
+interval:
+    intervalTimeStamp
+    | (
+        SECOND_MICROSECOND_SYMBOL
+        | MINUTE_MICROSECOND_SYMBOL
+        | MINUTE_SECOND_SYMBOL
+        | HOUR_MICROSECOND_SYMBOL
+        | HOUR_SECOND_SYMBOL
+        | HOUR_MINUTE_SYMBOL
+        | DAY_MICROSECOND_SYMBOL
+        | DAY_SECOND_SYMBOL
+        | DAY_MINUTE_SYMBOL
+        | DAY_HOUR_SYMBOL
+        | YEAR_MONTH_SYMBOL
+    )
+;
+
+// Support for SQL_TSI_* units is added by mapping those to tokens without SQL_TSI_ prefix.
+intervalTimeStamp:
+    MICROSECOND_SYMBOL
+    | SECOND_SYMBOL
+    | MINUTE_SYMBOL
+    | HOUR_SYMBOL
+    | DAY_SYMBOL
+    | WEEK_SYMBOL
+    | MONTH_SYMBOL
+    | QUARTER_SYMBOL
+    | YEAR_SYMBOL
+;
+
+exprListWithParentheses:
+    OPEN_PAR_SYMBOL exprList CLOSE_PAR_SYMBOL
+;
+
+exprWithParentheses:
+    OPEN_PAR_SYMBOL expr CLOSE_PAR_SYMBOL
+;
+
+simpleExprWithParentheses:
+    OPEN_PAR_SYMBOL simpleExpr CLOSE_PAR_SYMBOL
+;
+
+orderList:
+    orderExpression (COMMA_SYMBOL orderExpression)*
+;
+
+orderExpression:
+    expr direction?
+;
+
+groupList:
+    groupingExpression (COMMA_SYMBOL groupingExpression)*
+;
+
+groupingExpression:
+    expr
+;
+
+channel:
+    FOR_SYMBOL CHANNEL_SYMBOL textStringNoLinebreak
+;
+
+//----------------- Stored routines rules ------------------------------------------------------------------------------
+
+// Compound syntax for stored procedures, stored functions, triggers and events.
+// Implements both, sp_proc_stmt and ev_sql_stmt_inner from the server grammar.
+compoundStatement:
+    simpleStatement
+    | returnStatement
+    | ifStatement
+    | caseStatement
+    | labeledBlock
+    | unlabeledBlock
+    | labeledControl
+    | unlabeledControl
+    | leaveStatement
+    | iterateStatement
+    | cursorOpen
+    | cursorFetch
+    | cursorClose
+;
+
+returnStatement:
+    RETURN_SYMBOL expr
+;
+
+ifStatement:
+    IF_SYMBOL ifBody END_SYMBOL IF_SYMBOL
+;
+
+ifBody:
+    expr thenStatement (ELSEIF_SYMBOL ifBody | ELSE_SYMBOL compoundStatementList)?
+;
+
+thenStatement:
+    THEN_SYMBOL compoundStatementList
+;
+
+compoundStatementList: (compoundStatement SEMICOLON_SYMBOL)+
+;
+
+caseStatement:
+    CASE_SYMBOL expr? (whenExpression thenStatement)+ elseStatement? END_SYMBOL CASE_SYMBOL
+;
+
+elseStatement:
+    ELSE_SYMBOL compoundStatementList
+;
+
+labeledBlock:
+    label beginEndBlock labelRef?
+;
+
+unlabeledBlock:
+    beginEndBlock
+;
+
+label:
+    // Block labels can only be up to 16 characters long.
+    labelIdentifier COLON_SYMBOL
+;
+
+beginEndBlock:
+    BEGIN_SYMBOL spDeclarations? compoundStatementList? END_SYMBOL
+;
+
+labeledControl:
+    label unlabeledControl labelRef?
+;
+
+unlabeledControl:
+    loopBlock
+    | whileDoBlock
+    | repeatUntilBlock
+;
+
+loopBlock:
+    LOOP_SYMBOL compoundStatementList END_SYMBOL LOOP_SYMBOL
+;
+
+whileDoBlock:
+    WHILE_SYMBOL expr DO_SYMBOL compoundStatementList END_SYMBOL WHILE_SYMBOL
+;
+
+repeatUntilBlock:
+    REPEAT_SYMBOL compoundStatementList UNTIL_SYMBOL expr END_SYMBOL REPEAT_SYMBOL
+;
+
+spDeclarations: (spDeclaration SEMICOLON_SYMBOL)+
+;
+
+spDeclaration:
+    variableDeclaration
+    | conditionDeclaration
+    | handlerDeclaration
+    | cursorDeclaration
+;
+
+variableDeclaration:
+    DECLARE_SYMBOL identifierList dataType collate? (DEFAULT_SYMBOL expr)?
+;
+
+conditionDeclaration:
+    DECLARE_SYMBOL identifier CONDITION_SYMBOL FOR_SYMBOL spCondition
+;
+
+spCondition:
+    ulong_number
+    | sqlstate
+;
+
+sqlstate:
+    SQLSTATE_SYMBOL VALUE_SYMBOL? textLiteral
+;
+
+handlerDeclaration:
+    DECLARE_SYMBOL (CONTINUE_SYMBOL | EXIT_SYMBOL | UNDO_SYMBOL) HANDLER_SYMBOL FOR_SYMBOL handlerCondition (
+        COMMA_SYMBOL handlerCondition
+    )* compoundStatement
+;
+
+handlerCondition:
+    spCondition
+    | identifier
+    | SQLWARNING_SYMBOL
+    | notRule FOUND_SYMBOL
+    | SQLEXCEPTION_SYMBOL
+;
+
+cursorDeclaration:
+    DECLARE_SYMBOL identifier CURSOR_SYMBOL FOR_SYMBOL selectStatement
+;
+
+iterateStatement:
+    ITERATE_SYMBOL labelRef
+;
+
+leaveStatement:
+    LEAVE_SYMBOL labelRef
+;
+
+getDiagnosticsStatement:
+    GET_SYMBOL (CURRENT_SYMBOL | STACKED_SYMBOL)? DIAGNOSTICS_SYMBOL (
+        statementInformationItem (COMMA_SYMBOL statementInformationItem)*
+        | CONDITION_SYMBOL signalAllowedExpr conditionInformationItem (
+            COMMA_SYMBOL conditionInformationItem
+        )*
+    )
+;
+
+// Only a limited subset of expr is allowed in SIGNAL/RESIGNAL/CONDITIONS.
+signalAllowedExpr:
+    literal
+    | rvalueSystemOrUserVariable
+    | qualifiedIdentifier
+;
+
+statementInformationItem:
+    (userVariable | identifier) EQUAL_OPERATOR (NUMBER_SYMBOL | ROW_COUNT_SYMBOL)
+;
+
+conditionInformationItem:
+    (userVariable | identifier) EQUAL_OPERATOR (
+        signalInformationItemName
+        | RETURNED_SQLSTATE_SYMBOL
+    )
+;
+
+signalInformationItemName:
+    CLASS_ORIGIN_SYMBOL
+    | SUBCLASS_ORIGIN_SYMBOL
+    | CONSTRAINT_CATALOG_SYMBOL
+    | CONSTRAINT_SCHEMA_SYMBOL
+    | CONSTRAINT_NAME_SYMBOL
+    | CATALOG_NAME_SYMBOL
+    | SCHEMA_NAME_SYMBOL
+    | TABLE_NAME_SYMBOL
+    | COLUMN_NAME_SYMBOL
+    | CURSOR_NAME_SYMBOL
+    | MESSAGE_TEXT_SYMBOL
+    | MYSQL_ERRNO_SYMBOL
+;
+
+signalStatement:
+    SIGNAL_SYMBOL (identifier | sqlstate) (
+        SET_SYMBOL signalInformationItem (COMMA_SYMBOL signalInformationItem)*
+    )?
+;
+
+resignalStatement:
+    RESIGNAL_SYMBOL (identifier | sqlstate)? (
+        SET_SYMBOL signalInformationItem (COMMA_SYMBOL signalInformationItem)*
+    )?
+;
+
+signalInformationItem:
+    signalInformationItemName EQUAL_OPERATOR signalAllowedExpr
+;
+
+cursorOpen:
+    OPEN_SYMBOL identifier
+;
+
+cursorClose:
+    CLOSE_SYMBOL identifier
+;
+
+cursorFetch:
+    FETCH_SYMBOL (NEXT_SYMBOL? FROM_SYMBOL)? identifier INTO_SYMBOL identifierList
+;
+
+//----------------- Supplemental rules ---------------------------------------------------------------------------------
+
+// Schedules in CREATE/ALTER EVENT.
+schedule:
+    AT_SYMBOL expr
+    | EVERY_SYMBOL expr interval (STARTS_SYMBOL expr)? (ENDS_SYMBOL expr)?
+;
+
+columnDefinition:
+    columnName fieldDefinition checkOrReferences?
+;
+
+checkOrReferences:
+    {serverVersion < 80016}? checkConstraint
+    | references
+;
+
+checkConstraint:
+    CHECK_SYMBOL exprWithParentheses
+;
+
+constraintEnforcement:
+    { serverVersion >= 80017}? NOT_SYMBOL? ENFORCED_SYMBOL
+;
+
+tableConstraintDef:
+    type = (KEY_SYMBOL | INDEX_SYMBOL) indexNameAndType? keyListWithExpression indexOption*
+    | type = FULLTEXT_SYMBOL keyOrIndex? indexName? keyListWithExpression fulltextIndexOption*
+    | type = SPATIAL_SYMBOL keyOrIndex? indexName? keyListWithExpression spatialIndexOption*
+    | constraintName? (
+        (type = PRIMARY_SYMBOL KEY_SYMBOL | type = UNIQUE_SYMBOL keyOrIndex?) indexNameAndType? keyListWithExpression indexOption*
+        | type = FOREIGN_SYMBOL KEY_SYMBOL indexName? keyList references
+        | checkConstraint constraintEnforcement?
+    )
+;
+
+constraintName:
+    CONSTRAINT_SYMBOL identifier?
+;
+
+fieldDefinition:
+    dataType (
+        columnAttribute*
+        | collate? (GENERATED_SYMBOL ALWAYS_SYMBOL)? AS_SYMBOL exprWithParentheses (
+            VIRTUAL_SYMBOL
+            | STORED_SYMBOL
+        )? columnAttribute*
+    )
+;
+
+columnAttribute:
+    NOT_SYMBOL? nullLiteral
+    | {serverVersion >= 80014}? NOT_SYMBOL SECONDARY_SYMBOL
+    | value = DEFAULT_SYMBOL (
+        nowOrSignedLiteral
+        | {serverVersion >= 80013}? exprWithParentheses
+    )
+    | value = ON_SYMBOL UPDATE_SYMBOL NOW_SYMBOL timeFunctionParameters?
+    | value = AUTO_INCREMENT_SYMBOL
+    | value = SERIAL_SYMBOL DEFAULT_SYMBOL VALUE_SYMBOL
+    | PRIMARY_SYMBOL? value = KEY_SYMBOL
+    | value = UNIQUE_SYMBOL KEY_SYMBOL?
+    | value = COMMENT_SYMBOL textLiteral
+    | collate
+    | value = COLUMN_FORMAT_SYMBOL columnFormat
+    | value = STORAGE_SYMBOL storageMedia
+    | value = SRID_SYMBOL real_ulonglong_number
+    | {serverVersion >= 80017}? constraintName? checkConstraint
+    | {serverVersion >= 80017}? constraintEnforcement
+    | {serverVersion >= 80024}? value = ENGINE_ATTRIBUTE_SYMBOL EQUAL_OPERATOR? jsonAttribute
+    | {serverVersion >= 80024}? value = SECONDARY_ENGINE_ATTRIBUTE_SYMBOL EQUAL_OPERATOR? jsonAttribute
+    | {serverVersion >= 80024}? visibility
+;
+
+columnFormat:
+    FIXED_SYMBOL
+    | DYNAMIC_SYMBOL
+    | DEFAULT_SYMBOL
+;
+
+storageMedia:
+    DISK_SYMBOL
+    | MEMORY_SYMBOL
+    | DEFAULT_SYMBOL
+;
+
+now:
+    NOW_SYMBOL functionDatetimePrecision
+;
+
+nowOrSignedLiteral:
+    now
+    | signedLiteralOrNull
+;
+
+gcolAttribute:
+    UNIQUE_SYMBOL KEY_SYMBOL?
+    | COMMENT_SYMBOL textString
+    | notRule? NULL_SYMBOL
+    | PRIMARY_SYMBOL? KEY_SYMBOL
+;
+
+references:
+    REFERENCES_SYMBOL tableRef identifierListWithParentheses? (
+        MATCH_SYMBOL match = (FULL_SYMBOL | PARTIAL_SYMBOL | SIMPLE_SYMBOL)
+    )? (
+        ON_SYMBOL option = UPDATE_SYMBOL deleteOption (
+            ON_SYMBOL DELETE_SYMBOL deleteOption
+        )?
+        | ON_SYMBOL option = DELETE_SYMBOL deleteOption (
+            ON_SYMBOL UPDATE_SYMBOL deleteOption
+        )?
+    )?
+;
+
+deleteOption:
+    (RESTRICT_SYMBOL | CASCADE_SYMBOL)
+    | SET_SYMBOL nullLiteral
+    | SET_SYMBOL DEFAULT_SYMBOL
+    | NO_SYMBOL ACTION_SYMBOL
+;
+
+keyList:
+    OPEN_PAR_SYMBOL keyPart (COMMA_SYMBOL keyPart)* CLOSE_PAR_SYMBOL
+;
+
+keyPart:
+    identifier fieldLength? direction?
+;
+
+keyListWithExpression:
+    OPEN_PAR_SYMBOL keyPartOrExpression (COMMA_SYMBOL keyPartOrExpression)* CLOSE_PAR_SYMBOL
+;
+
+keyPartOrExpression: // key_part_with_expression in sql_yacc.yy.
+    keyPart
+    | {serverVersion >= 80013}? exprWithParentheses direction?
+;
+
+indexType:
+    algorithm = (BTREE_SYMBOL | RTREE_SYMBOL | HASH_SYMBOL)
+;
+
+indexOption:
+    commonIndexOption
+    | indexTypeClause
+;
+
+// These options are common for all index types.
+commonIndexOption:
+    KEY_BLOCK_SIZE_SYMBOL EQUAL_OPERATOR? ulong_number
+    | COMMENT_SYMBOL textLiteral
+    | visibility
+    | {serverVersion >= 80024}? ENGINE_ATTRIBUTE_SYMBOL EQUAL_OPERATOR? jsonAttribute
+    | {serverVersion >= 80024}? SECONDARY_ENGINE_ATTRIBUTE_SYMBOL EQUAL_OPERATOR? jsonAttribute
+;
+
+visibility:
+    VISIBLE_SYMBOL
+    | INVISIBLE_SYMBOL
+;
+
+indexTypeClause:
+    (USING_SYMBOL | TYPE_SYMBOL) indexType
+;
+
+fulltextIndexOption:
+    commonIndexOption
+    | WITH_SYMBOL PARSER_SYMBOL identifier
+;
+
+spatialIndexOption:
+    commonIndexOption
+;
+
+dataTypeDefinition: // For external use only. Don't reference this in the normal grammar.
+    dataType EOF
+;
+
+dataType: // type in sql_yacc.yy
+    type = (
+        INT_SYMBOL
+        | TINYINT_SYMBOL
+        | SMALLINT_SYMBOL
+        | MEDIUMINT_SYMBOL
+        | BIGINT_SYMBOL
+    ) fieldLength? fieldOptions?
+    | (type = REAL_SYMBOL | type = DOUBLE_SYMBOL PRECISION_SYMBOL?) precision? fieldOptions?
+    | type = (FLOAT_SYMBOL | DECIMAL_SYMBOL | NUMERIC_SYMBOL | FIXED_SYMBOL) floatOptions? fieldOptions?
+    | type = BIT_SYMBOL fieldLength?
+    | type = (BOOL_SYMBOL | BOOLEAN_SYMBOL)
+    | type = CHAR_SYMBOL fieldLength? charsetWithOptBinary?
+    | nchar fieldLength? BINARY_SYMBOL?
+    | type = BINARY_SYMBOL fieldLength?
+    | (type = CHAR_SYMBOL VARYING_SYMBOL | type = VARCHAR_SYMBOL) fieldLength charsetWithOptBinary?
+    | (
+        type = NATIONAL_SYMBOL VARCHAR_SYMBOL
+        | type = NVARCHAR_SYMBOL
+        | type = NCHAR_SYMBOL VARCHAR_SYMBOL
+        | type = NATIONAL_SYMBOL CHAR_SYMBOL VARYING_SYMBOL
+        | type = NCHAR_SYMBOL VARYING_SYMBOL
+    ) fieldLength BINARY_SYMBOL?
+    | type = VARBINARY_SYMBOL fieldLength
+    | type = YEAR_SYMBOL fieldLength? fieldOptions?
+    | type = DATE_SYMBOL
+    | type = TIME_SYMBOL typeDatetimePrecision?
+    | type = TIMESTAMP_SYMBOL typeDatetimePrecision?
+    | type = DATETIME_SYMBOL typeDatetimePrecision?
+    | type = TINYBLOB_SYMBOL
+    | type = BLOB_SYMBOL fieldLength?
+    | type = (MEDIUMBLOB_SYMBOL | LONGBLOB_SYMBOL)
+    | type = LONG_SYMBOL VARBINARY_SYMBOL
+    | type = LONG_SYMBOL (CHAR_SYMBOL VARYING_SYMBOL | VARCHAR_SYMBOL)? charsetWithOptBinary?
+    | type = TINYTEXT_SYMBOL charsetWithOptBinary?
+    | type = TEXT_SYMBOL fieldLength? charsetWithOptBinary?
+    | type = MEDIUMTEXT_SYMBOL charsetWithOptBinary?
+    | type = LONGTEXT_SYMBOL charsetWithOptBinary?
+    | type = ENUM_SYMBOL stringList charsetWithOptBinary?
+    | type = SET_SYMBOL stringList charsetWithOptBinary?
+    | type = SERIAL_SYMBOL
+    | type = JSON_SYMBOL
+    | type = (
+        GEOMETRY_SYMBOL
+        | GEOMETRYCOLLECTION_SYMBOL
+        | POINT_SYMBOL
+        | MULTIPOINT_SYMBOL
+        | LINESTRING_SYMBOL
+        | MULTILINESTRING_SYMBOL
+        | POLYGON_SYMBOL
+        | MULTIPOLYGON_SYMBOL
+    )
+;
+
+nchar:
+    type = NCHAR_SYMBOL
+    | type = NATIONAL_SYMBOL CHAR_SYMBOL
+;
+
+realType:
+    type = REAL_SYMBOL
+    | type = DOUBLE_SYMBOL PRECISION_SYMBOL?
+;
+
+fieldLength:
+    OPEN_PAR_SYMBOL (real_ulonglong_number | DECIMAL_NUMBER) CLOSE_PAR_SYMBOL
+;
+
+fieldOptions: (SIGNED_SYMBOL | UNSIGNED_SYMBOL | ZEROFILL_SYMBOL)+
+;
+
+charsetWithOptBinary:
+    ascii
+    | unicode
+    | BYTE_SYMBOL
+    | charset charsetName BINARY_SYMBOL?
+    | BINARY_SYMBOL (charset charsetName)?
+;
+
+ascii:
+    ASCII_SYMBOL BINARY_SYMBOL?
+    | BINARY_SYMBOL ASCII_SYMBOL
+;
+
+unicode:
+    UNICODE_SYMBOL BINARY_SYMBOL?
+    | BINARY_SYMBOL UNICODE_SYMBOL
+;
+
+wsNumCodepoints:
+    OPEN_PAR_SYMBOL real_ulong_number CLOSE_PAR_SYMBOL
+;
+
+typeDatetimePrecision:
+    OPEN_PAR_SYMBOL INT_NUMBER CLOSE_PAR_SYMBOL
+;
+
+functionDatetimePrecision:
+    | parentheses
+    | OPEN_PAR_SYMBOL INT_NUMBER CLOSE_PAR_SYMBOL
+;
+
+charsetName:
+    textOrIdentifier
+    | BINARY_SYMBOL
+    | {serverVersion < 80011}? DEFAULT_SYMBOL
+;
+
+collationName:
+    textOrIdentifier
+    | {serverVersion < 80011}? DEFAULT_SYMBOL
+    | {serverVersion >= 80018}? BINARY_SYMBOL
+;
+
+createTableOptions:
+    createTableOption (COMMA_SYMBOL? createTableOption)*
+;
+
+createTableOptionsEtc:
+    createTableOptions createPartitioningEtc?
+    | createPartitioningEtc
+;
+
+createPartitioningEtc:
+    partitionClause duplicateAsQe?
+    | duplicateAsQe
+;
+
+createTableOptionsSpaceSeparated:
+    createTableOption+
+;
+
+createTableOption: // In the order as they appear in the server grammar.
+    option = ENGINE_SYMBOL EQUAL_OPERATOR? engineRef
+    | {serverVersion >= 80014}? option = SECONDARY_ENGINE_SYMBOL equal? (
+        NULL_SYMBOL
+        | textOrIdentifier
+    )
+    | option = MAX_ROWS_SYMBOL EQUAL_OPERATOR? ulonglongNumber
+    | option = MIN_ROWS_SYMBOL EQUAL_OPERATOR? ulonglongNumber
+    | option = AVG_ROW_LENGTH_SYMBOL EQUAL_OPERATOR? ulonglongNumber
+    | option = PASSWORD_SYMBOL EQUAL_OPERATOR? textStringLiteral
+    | option = COMMENT_SYMBOL EQUAL_OPERATOR? textStringLiteral
+    | option = COMPRESSION_SYMBOL EQUAL_OPERATOR? textString
+    | option = ENCRYPTION_SYMBOL EQUAL_OPERATOR? textString
+    | option = AUTO_INCREMENT_SYMBOL EQUAL_OPERATOR? ulonglongNumber
+    | option = PACK_KEYS_SYMBOL EQUAL_OPERATOR? ternaryOption
+    | option = (
+        STATS_AUTO_RECALC_SYMBOL
+        | STATS_PERSISTENT_SYMBOL
+        | STATS_SAMPLE_PAGES_SYMBOL
+    ) EQUAL_OPERATOR? ternaryOption
+    | option = (CHECKSUM_SYMBOL | TABLE_CHECKSUM_SYMBOL) EQUAL_OPERATOR? ulong_number
+    | option = DELAY_KEY_WRITE_SYMBOL EQUAL_OPERATOR? ulong_number
+    | option = ROW_FORMAT_SYMBOL EQUAL_OPERATOR? format = (
+        DEFAULT_SYMBOL
+        | DYNAMIC_SYMBOL
+        | FIXED_SYMBOL
+        | COMPRESSED_SYMBOL
+        | REDUNDANT_SYMBOL
+        | COMPACT_SYMBOL
+    )
+    | option = UNION_SYMBOL EQUAL_OPERATOR? OPEN_PAR_SYMBOL tableRefList CLOSE_PAR_SYMBOL
+    | defaultCharset
+    | defaultCollation
+    | option = INSERT_METHOD_SYMBOL EQUAL_OPERATOR? method = (
+        NO_SYMBOL
+        | FIRST_SYMBOL
+        | LAST_SYMBOL
+    )
+    | option = DATA_SYMBOL DIRECTORY_SYMBOL EQUAL_OPERATOR? textString
+    | option = INDEX_SYMBOL DIRECTORY_SYMBOL EQUAL_OPERATOR? textString
+    | option = TABLESPACE_SYMBOL EQUAL_OPERATOR? identifier
+    | option = STORAGE_SYMBOL (DISK_SYMBOL | MEMORY_SYMBOL)
+    | option = CONNECTION_SYMBOL EQUAL_OPERATOR? textString
+    | option = KEY_BLOCK_SIZE_SYMBOL EQUAL_OPERATOR? ulonglongNumber
+    | {serverVersion >= 80024}? option = START_SYMBOL TRANSACTION_SYMBOL
+    | {serverVersion >= 80024}? option = ENGINE_ATTRIBUTE_SYMBOL EQUAL_OPERATOR? jsonAttribute
+    | {serverVersion >= 80024}? option = SECONDARY_ENGINE_ATTRIBUTE_SYMBOL EQUAL_OPERATOR? jsonAttribute
+    | {serverVersion >= 80024}? tsOptionAutoextendSize
+;
+
+ternaryOption:
+    ulong_number
+    | DEFAULT_SYMBOL
+;
+
+defaultCollation:
+    DEFAULT_SYMBOL? COLLATE_SYMBOL EQUAL_OPERATOR? collationName
+;
+
+defaultEncryption:
+    DEFAULT_SYMBOL? ENCRYPTION_SYMBOL EQUAL_OPERATOR? textStringLiteral
+;
+
+defaultCharset:
+    DEFAULT_SYMBOL? charset EQUAL_OPERATOR? charsetName
+;
+
+// Partition rules for CREATE/ALTER TABLE.
+partitionClause:
+    PARTITION_SYMBOL BY_SYMBOL partitionTypeDef (PARTITIONS_SYMBOL real_ulong_number)? subPartitions? partitionDefinitions?
+;
+
+partitionTypeDef:
+    LINEAR_SYMBOL? KEY_SYMBOL partitionKeyAlgorithm? OPEN_PAR_SYMBOL identifierList? CLOSE_PAR_SYMBOL # partitionDefKey
+    | LINEAR_SYMBOL? HASH_SYMBOL OPEN_PAR_SYMBOL bitExpr CLOSE_PAR_SYMBOL                             # partitionDefHash
+    | (RANGE_SYMBOL | LIST_SYMBOL) (
+        OPEN_PAR_SYMBOL bitExpr CLOSE_PAR_SYMBOL
+        | COLUMNS_SYMBOL OPEN_PAR_SYMBOL identifierList? CLOSE_PAR_SYMBOL
+    ) # partitionDefRangeList
+;
+
+subPartitions:
+    SUBPARTITION_SYMBOL BY_SYMBOL LINEAR_SYMBOL? (
+        HASH_SYMBOL OPEN_PAR_SYMBOL bitExpr CLOSE_PAR_SYMBOL
+        | KEY_SYMBOL partitionKeyAlgorithm? identifierListWithParentheses
+    ) (SUBPARTITIONS_SYMBOL real_ulong_number)?
+;
+
+partitionKeyAlgorithm: // Actually only 1 and 2 are allowed. Needs a semantic check.
+    ALGORITHM_SYMBOL EQUAL_OPERATOR real_ulong_number
+;
+
+partitionDefinitions:
+    OPEN_PAR_SYMBOL partitionDefinition (COMMA_SYMBOL partitionDefinition)* CLOSE_PAR_SYMBOL
+;
+
+partitionDefinition:
+    PARTITION_SYMBOL identifier (
+        VALUES_SYMBOL LESS_SYMBOL THAN_SYMBOL (
+            partitionValueItemListParen
+            | MAXVALUE_SYMBOL
+        )
+        | VALUES_SYMBOL IN_SYMBOL partitionValuesIn
+    )? partitionOption* (
+        OPEN_PAR_SYMBOL subpartitionDefinition (COMMA_SYMBOL subpartitionDefinition)* CLOSE_PAR_SYMBOL
+    )?
+;
+
+partitionValuesIn:
+    partitionValueItemListParen
+    | OPEN_PAR_SYMBOL partitionValueItemListParen (
+        COMMA_SYMBOL partitionValueItemListParen
+    )* CLOSE_PAR_SYMBOL
+;
+
+partitionOption:
+    option = TABLESPACE_SYMBOL EQUAL_OPERATOR? identifier
+    | STORAGE_SYMBOL? option = ENGINE_SYMBOL EQUAL_OPERATOR? engineRef
+    | option = NODEGROUP_SYMBOL EQUAL_OPERATOR? real_ulong_number
+    | option = (MAX_ROWS_SYMBOL | MIN_ROWS_SYMBOL) EQUAL_OPERATOR? real_ulong_number
+    | option = (DATA_SYMBOL | INDEX_SYMBOL) DIRECTORY_SYMBOL EQUAL_OPERATOR? textLiteral
+    | option = COMMENT_SYMBOL EQUAL_OPERATOR? textLiteral
+;
+
+subpartitionDefinition:
+    SUBPARTITION_SYMBOL textOrIdentifier partitionOption*
+;
+
+partitionValueItemListParen:
+    OPEN_PAR_SYMBOL partitionValueItem (COMMA_SYMBOL partitionValueItem)* CLOSE_PAR_SYMBOL
+;
+
+partitionValueItem:
+    bitExpr
+    | MAXVALUE_SYMBOL
+;
+
+definerClause:
+    DEFINER_SYMBOL EQUAL_OPERATOR user
+;
+
+ifExists:
+    IF_SYMBOL EXISTS_SYMBOL
+;
+
+ifExistsIdentifier:
+    ifExists persistedVariableIdentifier
+;
+
+persistedVariableIdentifier:
+    identifier
+    | {serverVersion >= 80032}? (qualifiedIdentifier | DEFAULT_SYMBOL dotIdentifier)
+;
+
+ifNotExists:
+    IF_SYMBOL notRule EXISTS_SYMBOL
+;
+
+ignoreUnknownUser:
+    IGNORE_SYMBOL UNKNOWN_SYMBOL USER_SYMBOL
+;
+
+procedureParameter:
+    type = (IN_SYMBOL | OUT_SYMBOL | INOUT_SYMBOL)? functionParameter
+;
+
+functionParameter:
+    parameterName typeWithOptCollate
+;
+
+collate:
+    COLLATE_SYMBOL collationName
+;
+
+typeWithOptCollate:
+    dataType collate?
+;
+
+schemaIdentifierPair:
+    OPEN_PAR_SYMBOL schemaRef COMMA_SYMBOL schemaRef CLOSE_PAR_SYMBOL
+;
+
+viewRefList:
+    viewRef (COMMA_SYMBOL viewRef)*
+;
+
+updateList:
+    updateElement (COMMA_SYMBOL updateElement)*
+;
+
+updateElement:
+    columnRef EQUAL_OPERATOR (expr | DEFAULT_SYMBOL)
+;
+
+charsetClause:
+    charset charsetName
+;
+
+fieldsClause:
+    COLUMNS_SYMBOL fieldTerm+
+;
+
+fieldTerm:
+    TERMINATED_SYMBOL BY_SYMBOL textString
+    | OPTIONALLY_SYMBOL? ENCLOSED_SYMBOL BY_SYMBOL textString
+    | ESCAPED_SYMBOL BY_SYMBOL textString
+;
+
+linesClause:
+    LINES_SYMBOL lineTerm+
+;
+
+lineTerm: (TERMINATED_SYMBOL | STARTING_SYMBOL) BY_SYMBOL textString
+;
+
+userList:
+    user (COMMA_SYMBOL user)*
+;
+
+createUserList:
+    createUser (COMMA_SYMBOL createUser)*
+;
+
+createUser:
+    user (
+        identification createUserWithMfa?
+        | identifiedWithPlugin initialAuth?
+        | createUserWithMfa
+    )?
+;
+
+createUserWithMfa:
+    AND_SYMBOL identification (AND_SYMBOL identification)?
+;
+
+identification:
+    identifiedByPassword
+    | identifiedByRandomPassword
+    | identifiedWithPlugin
+    | identifiedWithPluginAsAuth
+    | identifiedWithPluginByPassword
+    | identifiedWithPluginByRandomPassword
+;
+
+identifiedByPassword:
+    IDENTIFIED_SYMBOL BY_SYMBOL textStringLiteral
+;
+
+identifiedByRandomPassword:
+    IDENTIFIED_SYMBOL BY_SYMBOL RANDOM_SYMBOL PASSWORD_SYMBOL
+;
+
+identifiedWithPlugin:
+    IDENTIFIED_SYMBOL WITH_SYMBOL textOrIdentifier
+;
+
+identifiedWithPluginAsAuth:
+    IDENTIFIED_SYMBOL WITH_SYMBOL textOrIdentifier AS_SYMBOL textStringHash
+;
+
+identifiedWithPluginByPassword:
+    IDENTIFIED_SYMBOL WITH_SYMBOL textOrIdentifier BY_SYMBOL textStringLiteral
+;
+
+identifiedWithPluginByRandomPassword:
+    IDENTIFIED_SYMBOL WITH_SYMBOL textOrIdentifier BY_SYMBOL RANDOM_SYMBOL PASSWORD_SYMBOL
+;
+
+initialAuth:
+    INITIAL_SYMBOL AUTHENTICATION_SYMBOL (
+        identifiedByRandomPassword
+        | identifiedWithPluginAsAuth
+        | identifiedByPassword
+    )
+;
+
+retainCurrentPassword:
+    RETAIN_SYMBOL CURRENT_SYMBOL PASSWORD_SYMBOL
+;
+
+discardOldPassword:
+    DISCARD_SYMBOL OLD_SYMBOL PASSWORD_SYMBOL
+;
+
+userRegistration:
+    factor INITIATE_SYMBOL REGISTRATION_SYMBOL
+    | factor UNREGISTER_SYMBOL
+    | factor FINISH_SYMBOL REGISTRATION_SYMBOL SET_SYMBOL CHALLENGE_RESPONSE_SYMBOL AS_SYMBOL textStringHash
+;
+
+factor:
+    numLiteral FACTOR_SYMBOL
+;
+
+replacePassword:
+    REPLACE_SYMBOL textString
+;
+
+userIdentifierOrText:
+    textOrIdentifier userVariable?
+;
+
+user:
+    userIdentifierOrText
+    | CURRENT_USER_SYMBOL parentheses?
+;
+
+likeClause:
+    LIKE_SYMBOL textStringLiteral
+;
+
+likeOrWhere: // opt_wild_or_where in sql_yacc.yy
+    likeClause
+    | whereClause
+;
+
+onlineOption:
+    ONLINE_SYMBOL
+    | OFFLINE_SYMBOL
+;
+
+noWriteToBinLog:
+    LOCAL_SYMBOL
+    | NO_WRITE_TO_BINLOG_SYMBOL
+;
+
+usePartition:
+    PARTITION_SYMBOL identifierListWithParentheses
+;
+
+//----------------- Object names and references ------------------------------------------------------------------------
+
+// For each object we have at least 2 rules here:
+// 1) The name when creating that object.
+// 2) The name when used to reference it from other rules.
+//
+// Sometimes we need additional reference rules with different form, depending on the place such a reference is used.
+
+// A name for a field (column/index). Can be qualified with the current schema + table (although it's not a reference).
+fieldIdentifier:
+    dotIdentifier
+    | qualifiedIdentifier dotIdentifier?
+;
+
+columnName:
+    identifier
+;
+
+// A reference to a column of the object we are working on.
+columnInternalRef:
+    identifier
+;
+
+columnInternalRefList: // column_list (+ parentheses) + opt_derived_column_list in sql_yacc.yy
+    OPEN_PAR_SYMBOL columnInternalRef (COMMA_SYMBOL columnInternalRef)* CLOSE_PAR_SYMBOL
+;
+
+columnRef: // A field identifier that can reference any schema/table.
+    fieldIdentifier
+;
+
+insertIdentifier:
+    columnRef
+    | tableWild
+;
+
+indexName:
+    identifier
+;
+
+indexRef: // Always internal reference. Still all qualification variations are accepted.
+    fieldIdentifier
+;
+
+tableWild:
+    identifier DOT_SYMBOL (identifier DOT_SYMBOL)? MULT_OPERATOR
+;
+
+schemaName:
+    identifier
+;
+
+schemaRef:
+    identifier
+;
+
+procedureName:
+    qualifiedIdentifier
+;
+
+procedureRef:
+    qualifiedIdentifier
+;
+
+functionName:
+    qualifiedIdentifier
+;
+
+functionRef:
+    qualifiedIdentifier
+;
+
+triggerName:
+    qualifiedIdentifier
+;
+
+triggerRef:
+    qualifiedIdentifier
+;
+
+viewName:
+    qualifiedIdentifier
+    | dotIdentifier
+;
+
+viewRef:
+    qualifiedIdentifier
+    | dotIdentifier
+;
+
+tablespaceName:
+    identifier
+;
+
+tablespaceRef:
+    identifier
+;
+
+logfileGroupName:
+    identifier
+;
+
+logfileGroupRef:
+    identifier
+;
+
+eventName:
+    qualifiedIdentifier
+;
+
+eventRef:
+    qualifiedIdentifier
+;
+
+udfName: // UDFs are referenced at the same places as any other function. So, no dedicated *_ref here.
+    identifier
+;
+
+serverName:
+    textOrIdentifier
+;
+
+serverRef:
+    textOrIdentifier
+;
+
+engineRef:
+    textOrIdentifier
+;
+
+tableName:
+    qualifiedIdentifier
+    | dotIdentifier
+;
+
+filterTableRef: // Always qualified.
+    schemaRef dotIdentifier
+;
+
+tableRefWithWildcard:
+    identifier (DOT_SYMBOL MULT_OPERATOR | dotIdentifier (DOT_SYMBOL MULT_OPERATOR)?)?
+;
+
+tableRef:
+    qualifiedIdentifier
+    | dotIdentifier
+;
+
+tableRefList:
+    tableRef (COMMA_SYMBOL tableRef)*
+;
+
+tableAliasRefList:
+    tableRefWithWildcard (COMMA_SYMBOL tableRefWithWildcard)*
+;
+
+parameterName:
+    identifier
+;
+
+labelIdentifier:
+    pureIdentifier
+    | labelKeyword
+;
+
+labelRef:
+    labelIdentifier
+;
+
+roleIdentifier:
+    pureIdentifier
+    | roleKeyword
+;
+
+pluginRef:
+    identifier
+;
+
+componentRef:
+    textStringLiteral
+;
+
+resourceGroupRef:
+    identifier
+;
+
+windowName:
+    identifier
+;
+
+//----------------- Common basic rules ---------------------------------------------------------------------------------
+
+// Identifiers excluding keywords (except if they are quoted). IDENT_sys in sql_yacc.yy.
+pureIdentifier:
+    (IDENTIFIER | BACK_TICK_QUOTED_ID)
+    | {isSqlModeActive(AnsiQuotes)}? DOUBLE_QUOTED_TEXT
+;
+
+// Identifiers including a certain set of keywords, which are allowed also if not quoted.
+// ident in sql_yacc.yy
+identifier:
+    pureIdentifier
+    | identifierKeyword
+;
+
+identifierList: // ident_string_list in sql_yacc.yy.
+    identifier (COMMA_SYMBOL identifier)*
+;
+
+identifierListWithParentheses:
+    OPEN_PAR_SYMBOL identifierList CLOSE_PAR_SYMBOL
+;
+
+qualifiedIdentifier:
+    identifier dotIdentifier?
+;
+
+simpleIdentifier: // simple_ident + simple_ident_q
+    identifier (dotIdentifier dotIdentifier?)?
+;
+
+// This rule encapsulates the frequently used dot + identifier sequence, which also requires a special
+// treatment in the lexer. See there in the DOT_IDENTIFIER rule.
+dotIdentifier:
+    DOT_SYMBOL identifier
+;
+
+ulong_number:
+    INT_NUMBER
+    | HEX_NUMBER
+    | LONG_NUMBER
+    | ULONGLONG_NUMBER
+    | DECIMAL_NUMBER
+    | FLOAT_NUMBER
+;
+
+real_ulong_number:
+    INT_NUMBER
+    | HEX_NUMBER
+    | LONG_NUMBER
+    | ULONGLONG_NUMBER
+;
+
+ulonglongNumber:
+    INT_NUMBER
+    | LONG_NUMBER
+    | ULONGLONG_NUMBER
+    | DECIMAL_NUMBER
+    | FLOAT_NUMBER
+;
+
+real_ulonglong_number:
+    INT_NUMBER
+    | {serverVersion >= 80017}? HEX_NUMBER
+    | ULONGLONG_NUMBER
+    | LONG_NUMBER
+;
+
+signedLiteral:
+    literal
+    | PLUS_OPERATOR ulong_number
+    | MINUS_OPERATOR ulong_number
+;
+
+signedLiteralOrNull:
+    signedLiteral
+    | {serverVersion >= 80024}? nullAsLiteral
+;
+
+literal:
+    textLiteral
+    | numLiteral
+    | temporalLiteral
+    | nullLiteral
+    | boolLiteral
+    | UNDERSCORE_CHARSET? (HEX_NUMBER | BIN_NUMBER)
+;
+
+literalOrNull:
+    literal
+    | {serverVersion >= 80024}? nullAsLiteral
+;
+
+nullAsLiteral:
+    NULL_SYMBOL
+;
+
+stringList:
+    OPEN_PAR_SYMBOL textString (COMMA_SYMBOL textString)* CLOSE_PAR_SYMBOL
+;
+
+// TEXT_STRING_sys + TEXT_STRING_literal + TEXT_STRING_filesystem + TEXT_STRING + TEXT_STRING_password +
+// TEXT_STRING_validated in sql_yacc.yy.
+textStringLiteral:
+    value = SINGLE_QUOTED_TEXT
+    | {!isSqlModeActive(AnsiQuotes)}? value = DOUBLE_QUOTED_TEXT
+;
+
+textString:
+    textStringLiteral
+    | HEX_NUMBER
+    | BIN_NUMBER
+;
+
+textStringHash:
+    textStringLiteral
+    | {serverVersion >= 80017}? HEX_NUMBER
+;
+
+textLiteral:
+    (UNDERSCORE_CHARSET? textStringLiteral | NCHAR_TEXT) textStringLiteral*
+;
+
+// A special variant of a text string that must not contain a linebreak (TEXT_STRING_sys_nonewline in sql_yacc.yy).
+// Check validity in semantic phase.
+textStringNoLinebreak:
+    textStringLiteral
+;
+
+textStringLiteralList:
+    textStringLiteral (COMMA_SYMBOL textStringLiteral)*
+;
+
+numLiteral:
+    int64Literal
+    | DECIMAL_NUMBER
+    | FLOAT_NUMBER
+;
+
+boolLiteral:
+    TRUE_SYMBOL
+    | FALSE_SYMBOL
+;
+
+nullLiteral: // In sql_yacc.cc both 'NULL' and '\N' are mapped to NULL_SYMBOL(which is our nullLiteral).
+    NULL_SYMBOL
+    | NULL2_SYMBOL
+;
+
+// int64Literal if for unsigned exact integer literals in a range of [0 .. 2^64-1].
+int64Literal:
+    INT_NUMBER
+    | LONG_NUMBER
+    | ULONGLONG_NUMBER
+;
+
+temporalLiteral:
+    DATE_SYMBOL SINGLE_QUOTED_TEXT
+    | TIME_SYMBOL SINGLE_QUOTED_TEXT
+    | TIMESTAMP_SYMBOL SINGLE_QUOTED_TEXT
+;
+
+floatOptions:
+    fieldLength
+    | precision
+;
+
+standardFloatOptions:
+    precision
+;
+
+precision:
+    OPEN_PAR_SYMBOL INT_NUMBER COMMA_SYMBOL INT_NUMBER CLOSE_PAR_SYMBOL
+;
+
+textOrIdentifier:
+    identifier
+    | textStringLiteral
+;
+
+lValueIdentifier:
+    pureIdentifier
+    | lValueKeyword
+;
+
+roleIdentifierOrText:
+    roleIdentifier
+    | textStringLiteral
+;
+
+sizeNumber:
+    real_ulonglong_number
+    | pureIdentifier // Something like 10G. Semantic check needed for validity.
+;
+
+parentheses:
+    OPEN_PAR_SYMBOL CLOSE_PAR_SYMBOL
+;
+
+equal:
+    EQUAL_OPERATOR
+    | ASSIGN_OPERATOR
+;
+
+optionType:
+    PERSIST_SYMBOL
+    | PERSIST_ONLY_SYMBOL
+    | GLOBAL_SYMBOL
+    | LOCAL_SYMBOL
+    | SESSION_SYMBOL
+;
+
+rvalueSystemVariableType:
+    GLOBAL_SYMBOL DOT_SYMBOL
+    | LOCAL_SYMBOL DOT_SYMBOL
+    | SESSION_SYMBOL DOT_SYMBOL
+;
+
+setVarIdentType:
+    (
+        PERSIST_SYMBOL
+        | PERSIST_ONLY_SYMBOL
+        | GLOBAL_SYMBOL
+        | LOCAL_SYMBOL
+        | SESSION_SYMBOL
+    ) DOT_SYMBOL
+;
+
+jsonAttribute:
+    textStringLiteral
+;
+
+// Note: rules for non-reserved keywords have changed significantly with MySQL 8.0.17, which make their
+//       version dependent handling complicated.
+//       Comments for keyword rules are taken over directly from the server grammar, but usually don't apply here
+//       since we don't have something like shift/reduce conflicts in ANTLR4 (which those ugly rules try to overcome).
+
+// Non-reserved keywords are allowed as unquoted identifiers in general.
+//
+// OTOH, in a few particular cases statement-specific rules are used
+// instead of `ident_keyword` to avoid grammar ambiguities:
+//
+//  * `label_keyword` for SP label names
+//  * `role_keyword` for role names
+//  * `lvalue_keyword` for variable prefixes and names in left sides of
+//                     assignments in SET statements
+//
+// Normally, new non-reserved words should be added to the
+// the rule `ident_keywords_unambiguous`. If they cause grammar conflicts, try
+// one of `ident_keywords_ambiguous_...` rules instead.
+identifierKeyword:
+    {serverVersion < 80017}? (
+        labelKeyword
+        | roleOrIdentifierKeyword
+        | EXECUTE_SYMBOL
+        | SHUTDOWN_SYMBOL // Previously allowed as SP label as well.
+        | {serverVersion >= 80011}? RESTART_SYMBOL
+    )
+    | (
+        identifierKeywordsUnambiguous
+        | identifierKeywordsAmbiguous1RolesAndLabels
+        | identifierKeywordsAmbiguous2Labels
+        | identifierKeywordsAmbiguous3Roles
+        | identifierKeywordsAmbiguous4SystemVariables
+    )
+;
+
+// These non-reserved words cannot be used as role names and SP label names:
+identifierKeywordsAmbiguous1RolesAndLabels:
+    EXECUTE_SYMBOL
+    | RESTART_SYMBOL
+    | SHUTDOWN_SYMBOL
+;
+
+// These non-reserved keywords cannot be used as unquoted SP label names:
+identifierKeywordsAmbiguous2Labels:
+    ASCII_SYMBOL
+    | BEGIN_SYMBOL
+    | BYTE_SYMBOL
+    | CACHE_SYMBOL
+    | CHARSET_SYMBOL
+    | CHECKSUM_SYMBOL
+    | CLONE_SYMBOL
+    | COMMENT_SYMBOL
+    | COMMIT_SYMBOL
+    | CONTAINS_SYMBOL
+    | DEALLOCATE_SYMBOL
+    | DO_SYMBOL
+    | END_SYMBOL
+    | FLUSH_SYMBOL
+    | FOLLOWS_SYMBOL
+    | HANDLER_SYMBOL
+    | HELP_SYMBOL
+    | IMPORT_SYMBOL
+    | INSTALL_SYMBOL
+    | LANGUAGE_SYMBOL
+    | NO_SYMBOL
+    | PRECEDES_SYMBOL
+    | PREPARE_SYMBOL
+    | REPAIR_SYMBOL
+    | RESET_SYMBOL
+    | ROLLBACK_SYMBOL
+    | SAVEPOINT_SYMBOL
+    | SIGNED_SYMBOL
+    | SLAVE_SYMBOL
+    | START_SYMBOL
+    | STOP_SYMBOL
+    | TRUNCATE_SYMBOL
+    | UNICODE_SYMBOL
+    | UNINSTALL_SYMBOL
+    | XA_SYMBOL
+;
+
+// Keywords that we allow for labels in SPs in the unquoted form.
+// Any keyword that is allowed to begin a statement or routine characteristics
+// must be in `ident_keywords_ambiguous_2_labels` above, otherwise
+// we get (harmful) shift/reduce conflicts.
+//
+// Not allowed:
+//
+//   ident_keywords_ambiguous_1_roles_and_labels
+//   ident_keywords_ambiguous_2_labels
+labelKeyword:
+    {serverVersion < 80017}? (
+        roleOrLabelKeyword
+        | EVENT_SYMBOL
+        | FILE_SYMBOL
+        | NONE_SYMBOL
+        | PROCESS_SYMBOL
+        | PROXY_SYMBOL
+        | RELOAD_SYMBOL
+        | REPLICATION_SYMBOL
+        | RESOURCE_SYMBOL
+        | SUPER_SYMBOL
+    )
+    | (
+        identifierKeywordsUnambiguous
+        | identifierKeywordsAmbiguous3Roles
+        | identifierKeywordsAmbiguous4SystemVariables
+    )
+;
+
+// These non-reserved keywords cannot be used as unquoted role names:
+identifierKeywordsAmbiguous3Roles:
+    EVENT_SYMBOL
+    | FILE_SYMBOL
+    | NONE_SYMBOL
+    | PROCESS_SYMBOL
+    | PROXY_SYMBOL
+    | RELOAD_SYMBOL
+    | REPLICATION_SYMBOL
+    | RESOURCE_SYMBOL
+    | SUPER_SYMBOL
+;
+
+// These are the non-reserved keywords which may be used for unquoted
+// identifiers everywhere without introducing grammar conflicts:
+identifierKeywordsUnambiguous:
+    (
+        ACTION_SYMBOL
+        | ACCOUNT_SYMBOL
+        | ACTIVE_SYMBOL
+        | ADDDATE_SYMBOL
+        | ADMIN_SYMBOL
+        | AFTER_SYMBOL
+        | AGAINST_SYMBOL
+        | AGGREGATE_SYMBOL
+        | ALGORITHM_SYMBOL
+        | ALWAYS_SYMBOL
+        | ANY_SYMBOL
+        | AT_SYMBOL
+        | ATTRIBUTE_SYMBOL
+        | AUTHENTICATION_SYMBOL
+        | AUTOEXTEND_SIZE_SYMBOL
+        | AUTO_INCREMENT_SYMBOL
+        | AVG_ROW_LENGTH_SYMBOL
+        | AVG_SYMBOL
+        | BACKUP_SYMBOL
+        | BINLOG_SYMBOL
+        | BIT_SYMBOL
+        | BLOCK_SYMBOL
+        | BOOLEAN_SYMBOL
+        | BOOL_SYMBOL
+        | BTREE_SYMBOL
+        | BUCKETS_SYMBOL
+        | CASCADED_SYMBOL
+        | CATALOG_NAME_SYMBOL
+        | CHAIN_SYMBOL
+        | CHALLENGE_RESPONSE_SYMBOL
+        | CHANGED_SYMBOL
+        | CHANNEL_SYMBOL
+        | CIPHER_SYMBOL
+        | CLASS_ORIGIN_SYMBOL
+        | CLIENT_SYMBOL
+        | CLOSE_SYMBOL
+        | COALESCE_SYMBOL
+        | CODE_SYMBOL
+        | COLLATION_SYMBOL
+        | COLUMNS_SYMBOL
+        | COLUMN_FORMAT_SYMBOL
+        | COLUMN_NAME_SYMBOL
+        | COMMITTED_SYMBOL
+        | COMPACT_SYMBOL
+        | COMPLETION_SYMBOL
+        | COMPONENT_SYMBOL
+        | COMPRESSED_SYMBOL
+        | COMPRESSION_SYMBOL
+        | CONCURRENT_SYMBOL
+        | CONNECTION_SYMBOL
+        | CONSISTENT_SYMBOL
+        | CONSTRAINT_CATALOG_SYMBOL
+        | CONSTRAINT_NAME_SYMBOL
+        | CONSTRAINT_SCHEMA_SYMBOL
+        | CONTEXT_SYMBOL
+        | CPU_SYMBOL
+        | CURRENT_SYMBOL
+        | CURSOR_NAME_SYMBOL
+        | DATAFILE_SYMBOL
+        | DATA_SYMBOL
+        | DATETIME_SYMBOL
+        | DATE_SYMBOL
+        | DAY_SYMBOL
+        | DEFAULT_AUTH_SYMBOL
+        | DEFINER_SYMBOL
+        | DEFINITION_SYMBOL
+        | DELAY_KEY_WRITE_SYMBOL
+        | DESCRIPTION_SYMBOL
+        | DIAGNOSTICS_SYMBOL
+        | DIRECTORY_SYMBOL
+        | DISABLE_SYMBOL
+        | DISCARD_SYMBOL
+        | DISK_SYMBOL
+        | DUMPFILE_SYMBOL
+        | DUPLICATE_SYMBOL
+        | DYNAMIC_SYMBOL
+        | ENABLE_SYMBOL
+        | ENCRYPTION_SYMBOL
+        | ENDS_SYMBOL
+        | ENFORCED_SYMBOL
+        | ENGINES_SYMBOL
+        | ENGINE_SYMBOL
+        | ENUM_SYMBOL
+        | ERRORS_SYMBOL
+        | ERROR_SYMBOL
+        | ESCAPE_SYMBOL
+        | EVENTS_SYMBOL
+        | EVERY_SYMBOL
+        | EXCHANGE_SYMBOL
+        | EXCLUDE_SYMBOL
+        | EXPANSION_SYMBOL
+        | EXPIRE_SYMBOL
+        | EXPORT_SYMBOL
+        | EXTENDED_SYMBOL
+        | EXTENT_SIZE_SYMBOL
+        | FACTOR_SYMBOL
+        | FAST_SYMBOL
+        | FAULTS_SYMBOL
+        | FILE_BLOCK_SIZE_SYMBOL
+        | FILTER_SYMBOL
+        | FINISH_SYMBOL
+        | FIRST_SYMBOL
+        | FIXED_SYMBOL
+        | FOLLOWING_SYMBOL
+        | FORMAT_SYMBOL
+        | FOUND_SYMBOL
+        | FULL_SYMBOL
+        | GENERAL_SYMBOL
+        | GEOMETRYCOLLECTION_SYMBOL
+        | GEOMETRY_SYMBOL
+        | GET_FORMAT_SYMBOL
+        | GET_MASTER_PUBLIC_KEY_SYMBOL
+        | GET_SOURCE_PUBLIC_KEY_SYMBOL
+        | GRANTS_SYMBOL
+        | GROUP_REPLICATION_SYMBOL
+        | GTID_ONLY_SYMBOL
+        | HASH_SYMBOL
+        | HISTOGRAM_SYMBOL
+        | HISTORY_SYMBOL
+        | HOSTS_SYMBOL
+        | HOST_SYMBOL
+        | HOUR_SYMBOL
+        | IDENTIFIED_SYMBOL
+        | IGNORE_SERVER_IDS_SYMBOL
+        | INACTIVE_SYMBOL
+        | INDEXES_SYMBOL
+        | INITIAL_SIZE_SYMBOL
+        | INITIAL_SYMBOL
+        | INITIATE_SYMBOL
+        | INSERT_METHOD_SYMBOL
+        | INSTANCE_SYMBOL
+        | INVISIBLE_SYMBOL
+        | INVOKER_SYMBOL
+        | IO_SYMBOL
+        | IPC_SYMBOL
+        | ISOLATION_SYMBOL
+        | ISSUER_SYMBOL
+        | JSON_SYMBOL
+        | JSON_VALUE_SYMBOL
+        | KEY_BLOCK_SIZE_SYMBOL
+        | KEYRING_SYMBOL
+        | LAST_SYMBOL
+        | LEAVES_SYMBOL
+        | LESS_SYMBOL
+        | LEVEL_SYMBOL
+        | LINESTRING_SYMBOL
+        | LIST_SYMBOL
+        | LOCKED_SYMBOL
+        | LOCKS_SYMBOL
+        | LOGFILE_SYMBOL
+        | LOGS_SYMBOL
+        | MASTER_AUTO_POSITION_SYMBOL
+        | MASTER_COMPRESSION_ALGORITHM_SYMBOL
+        | MASTER_CONNECT_RETRY_SYMBOL
+        | MASTER_DELAY_SYMBOL
+        | MASTER_HEARTBEAT_PERIOD_SYMBOL
+        | MASTER_HOST_SYMBOL
+        | NETWORK_NAMESPACE_SYMBOL
+        | MASTER_LOG_FILE_SYMBOL
+        | MASTER_LOG_POS_SYMBOL
+        | MASTER_PASSWORD_SYMBOL
+        | MASTER_PORT_SYMBOL
+        | MASTER_PUBLIC_KEY_PATH_SYMBOL
+        | MASTER_RETRY_COUNT_SYMBOL
+        | MASTER_SSL_CAPATH_SYMBOL
+        | MASTER_SSL_CA_SYMBOL
+        | MASTER_SSL_CERT_SYMBOL
+        | MASTER_SSL_CIPHER_SYMBOL
+        | MASTER_SSL_CRLPATH_SYMBOL
+        | MASTER_SSL_CRL_SYMBOL
+        | MASTER_SSL_KEY_SYMBOL
+        | MASTER_SSL_SYMBOL
+        | MASTER_SYMBOL
+        | MASTER_TLS_CIPHERSUITES_SYMBOL
+        | MASTER_TLS_VERSION_SYMBOL
+        | MASTER_USER_SYMBOL
+        | MASTER_ZSTD_COMPRESSION_LEVEL_SYMBOL
+        | MAX_CONNECTIONS_PER_HOUR_SYMBOL
+        | MAX_QUERIES_PER_HOUR_SYMBOL
+        | MAX_ROWS_SYMBOL
+        | MAX_SIZE_SYMBOL
+        | MAX_UPDATES_PER_HOUR_SYMBOL
+        | MAX_USER_CONNECTIONS_SYMBOL
+        | MEDIUM_SYMBOL
+        | MEMORY_SYMBOL
+        | MERGE_SYMBOL
+        | MESSAGE_TEXT_SYMBOL
+        | MICROSECOND_SYMBOL
+        | MIGRATE_SYMBOL
+        | MINUTE_SYMBOL
+        | MIN_ROWS_SYMBOL
+        | MODE_SYMBOL
+        | MODIFY_SYMBOL
+        | MONTH_SYMBOL
+        | MULTILINESTRING_SYMBOL
+        | MULTIPOINT_SYMBOL
+        | MULTIPOLYGON_SYMBOL
+        | MUTEX_SYMBOL
+        | MYSQL_ERRNO_SYMBOL
+        | NAMES_SYMBOL
+        | NAME_SYMBOL
+        | NATIONAL_SYMBOL
+        | NCHAR_SYMBOL
+        | NDBCLUSTER_SYMBOL
+        | NESTED_SYMBOL
+        | NEVER_SYMBOL
+        | NEW_SYMBOL
+        | NEXT_SYMBOL
+        | NODEGROUP_SYMBOL
+        | NOWAIT_SYMBOL
+        | NO_WAIT_SYMBOL
+        | NULLS_SYMBOL
+        | NUMBER_SYMBOL
+        | NVARCHAR_SYMBOL
+        | OFFSET_SYMBOL
+        | OJ_SYMBOL
+        | OLD_SYMBOL
+        | ONE_SYMBOL
+        | ONLY_SYMBOL
+        | OPEN_SYMBOL
+        | OPTIONAL_SYMBOL
+        | OPTIONS_SYMBOL
+        | ORDINALITY_SYMBOL
+        | ORGANIZATION_SYMBOL
+        | OTHERS_SYMBOL
+        | OWNER_SYMBOL
+        | PACK_KEYS_SYMBOL
+        | PAGE_SYMBOL
+        | PARSER_SYMBOL
+        | PARTIAL_SYMBOL
+        | PARTITIONING_SYMBOL
+        | PARTITIONS_SYMBOL
+        | PASSWORD_SYMBOL
+        | PATH_SYMBOL
+        | PHASE_SYMBOL
+        | PLUGINS_SYMBOL
+        | PLUGIN_DIR_SYMBOL
+        | PLUGIN_SYMBOL
+        | POINT_SYMBOL
+        | POLYGON_SYMBOL
+        | PORT_SYMBOL
+        | PRECEDING_SYMBOL
+        | PRESERVE_SYMBOL
+        | PREV_SYMBOL
+        | PRIVILEGES_SYMBOL
+        | PRIVILEGE_CHECKS_USER_SYMBOL
+        | PROCESSLIST_SYMBOL
+        | PROFILES_SYMBOL
+        | PROFILE_SYMBOL
+        | QUARTER_SYMBOL
+        | QUERY_SYMBOL
+        | QUICK_SYMBOL
+        | READ_ONLY_SYMBOL
+        | REBUILD_SYMBOL
+        | RECOVER_SYMBOL
+        | REDO_BUFFER_SIZE_SYMBOL
+        | REDUNDANT_SYMBOL
+        | REFERENCE_SYMBOL
+        | REGISTRATION_SYMBOL
+        | RELAY_SYMBOL
+        | RELAYLOG_SYMBOL
+        | RELAY_LOG_FILE_SYMBOL
+        | RELAY_LOG_POS_SYMBOL
+        | RELAY_THREAD_SYMBOL
+        | REMOVE_SYMBOL
+        | ASSIGN_GTIDS_TO_ANONYMOUS_TRANSACTIONS_SYMBOL
+        | REORGANIZE_SYMBOL
+        | REPEATABLE_SYMBOL
+        | REPLICAS_SYMBOL
+        | REPLICATE_DO_DB_SYMBOL
+        | REPLICATE_DO_TABLE_SYMBOL
+        | REPLICATE_IGNORE_DB_SYMBOL
+        | REPLICATE_IGNORE_TABLE_SYMBOL
+        | REPLICATE_REWRITE_DB_SYMBOL
+        | REPLICATE_WILD_DO_TABLE_SYMBOL
+        | REPLICATE_WILD_IGNORE_TABLE_SYMBOL
+        | REPLICA_SYMBOL
+        | USER_RESOURCES_SYMBOL
+        | RESPECT_SYMBOL
+        | RESTORE_SYMBOL
+        | RESUME_SYMBOL
+        | RETAIN_SYMBOL
+        | RETURNED_SQLSTATE_SYMBOL
+        | RETURNING_SYMBOL
+        | RETURNS_SYMBOL
+        | REUSE_SYMBOL
+        | REVERSE_SYMBOL
+        | ROLE_SYMBOL
+        | ROLLUP_SYMBOL
+        | ROTATE_SYMBOL
+        | ROUTINE_SYMBOL
+        | ROW_COUNT_SYMBOL
+        | ROW_FORMAT_SYMBOL
+        | RTREE_SYMBOL
+        | SCHEDULE_SYMBOL
+        | SCHEMA_NAME_SYMBOL
+        | SECONDARY_ENGINE_SYMBOL
+        | SECONDARY_ENGINE_ATTRIBUTE_SYMBOL
+        | SECONDARY_LOAD_SYMBOL
+        | SECONDARY_SYMBOL
+        | SECONDARY_UNLOAD_SYMBOL
+        | SECOND_SYMBOL
+        | SECURITY_SYMBOL
+        | SERIALIZABLE_SYMBOL
+        | SERIAL_SYMBOL
+        | SERVER_SYMBOL
+        | SHARE_SYMBOL
+        | SIMPLE_SYMBOL
+        | SKIP_SYMBOL
+        | SLOW_SYMBOL
+        | SNAPSHOT_SYMBOL
+        | SOCKET_SYMBOL
+        | SONAME_SYMBOL
+        | SOUNDS_SYMBOL
+        | SOURCE_AUTO_POSITION_SYMBOL
+        | SOURCE_BIND_SYMBOL
+        | SOURCE_COMPRESSION_ALGORITHM_SYMBOL
+        | SOURCE_CONNECTION_AUTO_FAILOVER_SYMBOL
+        | SOURCE_CONNECT_RETRY_SYMBOL
+        | SOURCE_DELAY_SYMBOL
+        | SOURCE_HEARTBEAT_PERIOD_SYMBOL
+        | SOURCE_HOST_SYMBOL
+        | SOURCE_LOG_FILE_SYMBOL
+        | SOURCE_LOG_POS_SYMBOL
+        | SOURCE_PASSWORD_SYMBOL
+        | SOURCE_PORT_SYMBOL
+        | SOURCE_PUBLIC_KEY_PATH_SYMBOL
+        | SOURCE_RETRY_COUNT_SYMBOL
+        | SOURCE_SSL_CAPATH_SYMBOL
+        | SOURCE_SSL_CA_SYMBOL
+        | SOURCE_SSL_CERT_SYMBOL
+        | SOURCE_SSL_CIPHER_SYMBOL
+        | SOURCE_SSL_CRLPATH_SYMBOL
+        | SOURCE_SSL_CRL_SYMBOL
+        | SOURCE_SSL_KEY_SYMBOL
+        | SOURCE_SSL_SYMBOL
+        | SOURCE_SSL_VERIFY_SERVER_CERT_SYMBOL
+        | SOURCE_SYMBOL
+        | SOURCE_TLS_CIPHERSUITES_SYMBOL
+        | SOURCE_TLS_VERSION_SYMBOL
+        | SOURCE_USER_SYMBOL
+        | SOURCE_ZSTD_COMPRESSION_LEVEL_SYMBOL
+        | SQL_AFTER_GTIDS_SYMBOL
+        | SQL_AFTER_MTS_GAPS_SYMBOL
+        | SQL_BEFORE_GTIDS_SYMBOL
+        | SQL_BUFFER_RESULT_SYMBOL
+        | SQL_NO_CACHE_SYMBOL
+        | SQL_THREAD_SYMBOL
+        | SRID_SYMBOL
+        | STACKED_SYMBOL
+        | STARTS_SYMBOL
+        | STATS_AUTO_RECALC_SYMBOL
+        | STATS_PERSISTENT_SYMBOL
+        | STATS_SAMPLE_PAGES_SYMBOL
+        | STATUS_SYMBOL
+        | STORAGE_SYMBOL
+        | STRING_SYMBOL
+        | ST_COLLECT_SYMBOL
+        | SUBCLASS_ORIGIN_SYMBOL
+        | SUBDATE_SYMBOL
+        | SUBJECT_SYMBOL
+        | SUBPARTITIONS_SYMBOL
+        | SUBPARTITION_SYMBOL
+        | SUSPEND_SYMBOL
+        | SWAPS_SYMBOL
+        | SWITCHES_SYMBOL
+        | TABLES_SYMBOL
+        | TABLESPACE_SYMBOL
+        | TABLE_CHECKSUM_SYMBOL
+        | TABLE_NAME_SYMBOL
+        | TEMPORARY_SYMBOL
+        | TEMPTABLE_SYMBOL
+        | TEXT_SYMBOL
+        | THAN_SYMBOL
+        | THREAD_PRIORITY_SYMBOL
+        | TIES_SYMBOL
+        | TIMESTAMPADD_SYMBOL
+        | TIMESTAMPDIFF_SYMBOL
+        | TIMESTAMP_SYMBOL
+        | TIME_SYMBOL
+        | TLS_SYMBOL
+        | TRANSACTION_SYMBOL
+        | TRIGGERS_SYMBOL
+        | TYPES_SYMBOL
+        | TYPE_SYMBOL
+        | UNBOUNDED_SYMBOL
+        | UNCOMMITTED_SYMBOL
+        | UNDEFINED_SYMBOL
+        | UNDOFILE_SYMBOL
+        | UNDO_BUFFER_SIZE_SYMBOL
+        | UNKNOWN_SYMBOL
+        | UNREGISTER_SYMBOL
+        | UNTIL_SYMBOL
+        | UPGRADE_SYMBOL
+        | USER_SYMBOL
+        | USE_FRM_SYMBOL
+        | VALIDATION_SYMBOL
+        | VALUE_SYMBOL
+        | VARIABLES_SYMBOL
+        | VCPU_SYMBOL
+        | VIEW_SYMBOL
+        | VISIBLE_SYMBOL
+        | WAIT_SYMBOL
+        | WARNINGS_SYMBOL
+        | WEEK_SYMBOL
+        | WEIGHT_STRING_SYMBOL
+        | WITHOUT_SYMBOL
+        | WORK_SYMBOL
+        | WRAPPER_SYMBOL
+        | X509_SYMBOL
+        | XID_SYMBOL
+        | XML_SYMBOL
+        | YEAR_SYMBOL
+        | ZONE_SYMBOL
+    )
+    | {serverVersion >= 80019}? (
+        ARRAY_SYMBOL
+        | FAILED_LOGIN_ATTEMPTS_SYMBOL
+        | MASTER_COMPRESSION_ALGORITHM_SYMBOL
+        | MASTER_TLS_CIPHERSUITES_SYMBOL
+        | MASTER_ZSTD_COMPRESSION_LEVEL_SYMBOL
+        | MEMBER_SYMBOL
+        | OFF_SYMBOL
+        | PASSWORD_LOCK_TIME_SYMBOL
+        | PRIVILEGE_CHECKS_USER_SYMBOL
+        | RANDOM_SYMBOL
+        | REQUIRE_ROW_FORMAT_SYMBOL
+        | REQUIRE_TABLE_PRIMARY_KEY_CHECK_SYMBOL
+        | STREAM_SYMBOL
+        | TIMESTAMP_SYMBOL
+        | TIME_SYMBOL
+    )
+    | {serverVersion >= 80200}? (
+        BULK_SYMBOL
+        | GENERATE_SYMBOL
+        | GTIDS_SYMBOL
+        | LOG_SYMBOL
+        | PARSE_TREE_SYMBOL
+        | S3_SYMBOL
+        | BENROULLI_SYMBOL
+    )
+    /* INSERT OTHER KEYWORDS HERE */
+;
+
+// Non-reserved keywords that we allow for unquoted role names:
+//
+//  Not allowed:
+//
+//    ident_keywords_ambiguous_1_roles_and_labels
+//    ident_keywords_ambiguous_3_roles
+roleKeyword:
+    {serverVersion < 80017}? (roleOrLabelKeyword | roleOrIdentifierKeyword)
+    | (
+        identifierKeywordsUnambiguous
+        | identifierKeywordsAmbiguous2Labels
+        | identifierKeywordsAmbiguous4SystemVariables
+    )
+;
+
+// Non-reserved words allowed for unquoted unprefixed variable names and
+// unquoted variable prefixes in the left side of assignments in SET statements:
+//
+// Not allowed:
+//
+//   ident_keywords_ambiguous_4_system_variables
+lValueKeyword:
+    identifierKeywordsUnambiguous
+    | identifierKeywordsAmbiguous1RolesAndLabels
+    | identifierKeywordsAmbiguous2Labels
+    | identifierKeywordsAmbiguous3Roles
+;
+
+// These non-reserved keywords cannot be used as unquoted unprefixed
+// variable names and unquoted variable prefixes in the left side of
+// assignments in SET statements:
+identifierKeywordsAmbiguous4SystemVariables:
+    GLOBAL_SYMBOL
+    | LOCAL_SYMBOL
+    | PERSIST_SYMBOL
+    | PERSIST_ONLY_SYMBOL
+    | SESSION_SYMBOL
+;
+
+// $antlr-format groupedAlignments off
+
+// These are the non-reserved keywords which may be used for roles or idents.
+// Keywords defined only for specific server versions are handled at lexer level and so cannot match this rule
+// if the current server version doesn't allow them. Hence we don't need predicates here for them.
+roleOrIdentifierKeyword:
+    (
+        ACCOUNT_SYMBOL
+        | ASCII_SYMBOL
+        | ALWAYS_SYMBOL
+        | BACKUP_SYMBOL
+        | BEGIN_SYMBOL
+        | BYTE_SYMBOL
+        | CACHE_SYMBOL
+        | CHARSET_SYMBOL
+        | CHECKSUM_SYMBOL
+        | CLONE_SYMBOL
+        | CLOSE_SYMBOL
+        | COMMENT_SYMBOL
+        | COMMIT_SYMBOL
+        | CONTAINS_SYMBOL
+        | DEALLOCATE_SYMBOL
+        | DO_SYMBOL
+        | END_SYMBOL
+        | FLUSH_SYMBOL
+        | FOLLOWS_SYMBOL
+        | FORMAT_SYMBOL
+        | GROUP_REPLICATION_SYMBOL
+        | HANDLER_SYMBOL
+        | HELP_SYMBOL
+        | HOST_SYMBOL
+        | INSTALL_SYMBOL
+        | INVISIBLE_SYMBOL
+        | LANGUAGE_SYMBOL
+        | NO_SYMBOL
+        | OPEN_SYMBOL
+        | OPTIONS_SYMBOL
+        | OWNER_SYMBOL
+        | PARSER_SYMBOL
+        | PARTITION_SYMBOL
+        | PORT_SYMBOL
+        | PRECEDES_SYMBOL
+        | PREPARE_SYMBOL
+        | REMOVE_SYMBOL
+        | REPAIR_SYMBOL
+        | RESET_SYMBOL
+        | RESTORE_SYMBOL
+        | ROLE_SYMBOL
+        | ROLLBACK_SYMBOL
+        | SAVEPOINT_SYMBOL
+        | SECONDARY_SYMBOL
+        | SECONDARY_ENGINE_SYMBOL
+        | SECONDARY_LOAD_SYMBOL
+        | SECONDARY_UNLOAD_SYMBOL
+        | SECURITY_SYMBOL
+        | SERVER_SYMBOL
+        | SIGNED_SYMBOL
+        | SOCKET_SYMBOL
+        | SLAVE_SYMBOL
+        | SONAME_SYMBOL
+        | START_SYMBOL
+        | STOP_SYMBOL
+        | TRUNCATE_SYMBOL
+        | UNICODE_SYMBOL
+        | UNINSTALL_SYMBOL
+        | UPGRADE_SYMBOL
+        | VISIBLE_SYMBOL
+        | WRAPPER_SYMBOL
+        | XA_SYMBOL
+    )
+;
+
+roleOrLabelKeyword:
+    (
+        ACTION_SYMBOL
+        | ACTIVE_SYMBOL
+        | ADDDATE_SYMBOL
+        | AFTER_SYMBOL
+        | AGAINST_SYMBOL
+        | AGGREGATE_SYMBOL
+        | ALGORITHM_SYMBOL
+        | ANY_SYMBOL
+        | AT_SYMBOL
+        | AUTO_INCREMENT_SYMBOL
+        | AUTOEXTEND_SIZE_SYMBOL
+        | AVG_ROW_LENGTH_SYMBOL
+        | AVG_SYMBOL
+        | BINLOG_SYMBOL
+        | BIT_SYMBOL
+        | BLOCK_SYMBOL
+        | BOOL_SYMBOL
+        | BOOLEAN_SYMBOL
+        | BTREE_SYMBOL
+        | BUCKETS_SYMBOL
+        | CASCADED_SYMBOL
+        | CATALOG_NAME_SYMBOL
+        | CHAIN_SYMBOL
+        | CHANGED_SYMBOL
+        | CHANNEL_SYMBOL
+        | CIPHER_SYMBOL
+        | CLIENT_SYMBOL
+        | CLASS_ORIGIN_SYMBOL
+        | COALESCE_SYMBOL
+        | CODE_SYMBOL
+        | COLLATION_SYMBOL
+        | COLUMN_NAME_SYMBOL
+        | COLUMN_FORMAT_SYMBOL
+        | COLUMNS_SYMBOL
+        | COMMITTED_SYMBOL
+        | COMPACT_SYMBOL
+        | COMPLETION_SYMBOL
+        | COMPONENT_SYMBOL
+        | COMPRESSED_SYMBOL
+        | COMPRESSION_SYMBOL
+        | CONCURRENT_SYMBOL
+        | CONNECTION_SYMBOL
+        | CONSISTENT_SYMBOL
+        | CONSTRAINT_CATALOG_SYMBOL
+        | CONSTRAINT_SCHEMA_SYMBOL
+        | CONSTRAINT_NAME_SYMBOL
+        | CONTEXT_SYMBOL
+        | CPU_SYMBOL
+        | CURRENT_SYMBOL
+        | CURSOR_NAME_SYMBOL
+        | DATA_SYMBOL
+        | DATAFILE_SYMBOL
+        | DATETIME_SYMBOL
+        | DATE_SYMBOL
+        | DAY_SYMBOL
+        | DEFAULT_AUTH_SYMBOL
+        | DEFINER_SYMBOL
+        | DELAY_KEY_WRITE_SYMBOL
+        | DESCRIPTION_SYMBOL
+        | DIAGNOSTICS_SYMBOL
+        | DIRECTORY_SYMBOL
+        | DISABLE_SYMBOL
+        | DISCARD_SYMBOL
+        | DISK_SYMBOL
+        | DUMPFILE_SYMBOL
+        | DUPLICATE_SYMBOL
+        | DYNAMIC_SYMBOL
+        | ENCRYPTION_SYMBOL
+        | ENDS_SYMBOL
+        | ENUM_SYMBOL
+        | ENGINE_SYMBOL
+        | ENGINES_SYMBOL
+        | ENGINE_ATTRIBUTE_SYMBOL
+        | ERROR_SYMBOL
+        | ERRORS_SYMBOL
+        | ESCAPE_SYMBOL
+        | EVENTS_SYMBOL
+        | EVERY_SYMBOL
+        | EXCLUDE_SYMBOL
+        | EXPANSION_SYMBOL
+        | EXPORT_SYMBOL
+        | EXTENDED_SYMBOL
+        | EXTENT_SIZE_SYMBOL
+        | FAULTS_SYMBOL
+        | FAST_SYMBOL
+        | FOLLOWING_SYMBOL
+        | FOUND_SYMBOL
+        | ENABLE_SYMBOL
+        | FULL_SYMBOL
+        | FILE_BLOCK_SIZE_SYMBOL
+        | FILTER_SYMBOL
+        | FIRST_SYMBOL
+        | FIXED_SYMBOL
+        | GENERAL_SYMBOL
+        | GEOMETRY_SYMBOL
+        | GEOMETRYCOLLECTION_SYMBOL
+        | GET_FORMAT_SYMBOL
+        | GRANTS_SYMBOL
+        | GLOBAL_SYMBOL
+        | HASH_SYMBOL
+        | HISTOGRAM_SYMBOL
+        | HISTORY_SYMBOL
+        | HOSTS_SYMBOL
+        | HOUR_SYMBOL
+        | IDENTIFIED_SYMBOL
+        | IGNORE_SERVER_IDS_SYMBOL
+        | INVOKER_SYMBOL
+        | INDEXES_SYMBOL
+        | INITIAL_SIZE_SYMBOL
+        | INSTANCE_SYMBOL
+        | INACTIVE_SYMBOL
+        | IO_SYMBOL
+        | IPC_SYMBOL
+        | ISOLATION_SYMBOL
+        | ISSUER_SYMBOL
+        | INSERT_METHOD_SYMBOL
+        | JSON_SYMBOL
+        | KEY_BLOCK_SIZE_SYMBOL
+        | LAST_SYMBOL
+        | LEAVES_SYMBOL
+        | LESS_SYMBOL
+        | LEVEL_SYMBOL
+        | LINESTRING_SYMBOL
+        | LIST_SYMBOL
+        | LOCAL_SYMBOL
+        | LOCKED_SYMBOL
+        | LOCKS_SYMBOL
+        | LOGFILE_SYMBOL
+        | LOGS_SYMBOL
+        | MAX_ROWS_SYMBOL
+        | MASTER_SYMBOL
+        | MASTER_HEARTBEAT_PERIOD_SYMBOL
+        | MASTER_HOST_SYMBOL
+        | MASTER_PORT_SYMBOL
+        | MASTER_LOG_FILE_SYMBOL
+        | MASTER_LOG_POS_SYMBOL
+        | MASTER_USER_SYMBOL
+        | MASTER_PASSWORD_SYMBOL
+        | MASTER_PUBLIC_KEY_PATH_SYMBOL
+        | MASTER_CONNECT_RETRY_SYMBOL
+        | MASTER_RETRY_COUNT_SYMBOL
+        | MASTER_DELAY_SYMBOL
+        | MASTER_SSL_SYMBOL
+        | MASTER_SSL_CA_SYMBOL
+        | MASTER_SSL_CAPATH_SYMBOL
+        | MASTER_TLS_VERSION_SYMBOL
+        | MASTER_SSL_CERT_SYMBOL
+        | MASTER_SSL_CIPHER_SYMBOL
+        | MASTER_SSL_CRL_SYMBOL
+        | MASTER_SSL_CRLPATH_SYMBOL
+        | MASTER_SSL_KEY_SYMBOL
+        | MASTER_AUTO_POSITION_SYMBOL
+        | MAX_CONNECTIONS_PER_HOUR_SYMBOL
+        | MAX_QUERIES_PER_HOUR_SYMBOL
+        | MAX_SIZE_SYMBOL
+        | MAX_UPDATES_PER_HOUR_SYMBOL
+        | MAX_USER_CONNECTIONS_SYMBOL
+        | MEDIUM_SYMBOL
+        | MEMORY_SYMBOL
+        | MERGE_SYMBOL
+        | MESSAGE_TEXT_SYMBOL
+        | MICROSECOND_SYMBOL
+        | MIGRATE_SYMBOL
+        | MINUTE_SYMBOL
+        | MIN_ROWS_SYMBOL
+        | MODIFY_SYMBOL
+        | MODE_SYMBOL
+        | MONTH_SYMBOL
+        | MULTILINESTRING_SYMBOL
+        | MULTIPOINT_SYMBOL
+        | MULTIPOLYGON_SYMBOL
+        | MUTEX_SYMBOL
+        | MYSQL_ERRNO_SYMBOL
+        | NAME_SYMBOL
+        | NAMES_SYMBOL
+        | NATIONAL_SYMBOL
+        | NCHAR_SYMBOL
+        | NDBCLUSTER_SYMBOL
+        | NESTED_SYMBOL
+        | NEVER_SYMBOL
+        | NEXT_SYMBOL
+        | NEW_SYMBOL
+        | NO_WAIT_SYMBOL
+        | NODEGROUP_SYMBOL
+        | NULLS_SYMBOL
+        | NOWAIT_SYMBOL
+        | NUMBER_SYMBOL
+        | NVARCHAR_SYMBOL
+        | OFFSET_SYMBOL
+        | OLD_SYMBOL
+        | ONE_SYMBOL
+        | OPTIONAL_SYMBOL
+        | ORDINALITY_SYMBOL
+        | ORGANIZATION_SYMBOL
+        | OTHERS_SYMBOL
+        | PACK_KEYS_SYMBOL
+        | PAGE_SYMBOL
+        | PARTIAL_SYMBOL
+        | PARTITIONING_SYMBOL
+        | PARTITIONS_SYMBOL
+        | PASSWORD_SYMBOL
+        | PATH_SYMBOL
+        | PHASE_SYMBOL
+        | PLUGIN_DIR_SYMBOL
+        | PLUGIN_SYMBOL
+        | PLUGINS_SYMBOL
+        | POINT_SYMBOL
+        | POLYGON_SYMBOL
+        | PRECEDING_SYMBOL
+        | PRESERVE_SYMBOL
+        | PREV_SYMBOL
+        | THREAD_PRIORITY_SYMBOL
+        | PRIVILEGES_SYMBOL
+        | PROCESSLIST_SYMBOL
+        | PROFILE_SYMBOL
+        | PROFILES_SYMBOL
+        | QUARTER_SYMBOL
+        | QUERY_SYMBOL
+        | QUICK_SYMBOL
+        | READ_ONLY_SYMBOL
+        | REBUILD_SYMBOL
+        | RECOVER_SYMBOL
+        | REDO_BUFFER_SIZE_SYMBOL
+        | REDUNDANT_SYMBOL
+        | RELAY_SYMBOL
+        | RELAYLOG_SYMBOL
+        | RELAY_LOG_FILE_SYMBOL
+        | RELAY_LOG_POS_SYMBOL
+        | RELAY_THREAD_SYMBOL
+        | REMOTE_SYMBOL
+        | REORGANIZE_SYMBOL
+        | REPEATABLE_SYMBOL
+        | REPLICATE_DO_DB_SYMBOL
+        | REPLICATE_IGNORE_DB_SYMBOL
+        | REPLICATE_DO_TABLE_SYMBOL
+        | REPLICATE_IGNORE_TABLE_SYMBOL
+        | REPLICATE_WILD_DO_TABLE_SYMBOL
+        | REPLICATE_WILD_IGNORE_TABLE_SYMBOL
+        | REPLICATE_REWRITE_DB_SYMBOL
+        | USER_RESOURCES_SYMBOL
+        | RESPECT_SYMBOL
+        | RESUME_SYMBOL
+        | RETAIN_SYMBOL
+        | RETURNED_SQLSTATE_SYMBOL
+        | RETURNS_SYMBOL
+        | REUSE_SYMBOL
+        | REVERSE_SYMBOL
+        | ROLLUP_SYMBOL
+        | ROTATE_SYMBOL
+        | ROUTINE_SYMBOL
+        | ROW_COUNT_SYMBOL
+        | ROW_FORMAT_SYMBOL
+        | RTREE_SYMBOL
+        | SCHEDULE_SYMBOL
+        | SCHEMA_NAME_SYMBOL
+        | SECOND_SYMBOL
+        | SERIAL_SYMBOL
+        | SERIALIZABLE_SYMBOL
+        | SESSION_SYMBOL
+        | SHARE_SYMBOL
+        | SIMPLE_SYMBOL
+        | SKIP_SYMBOL
+        | SLOW_SYMBOL
+        | SNAPSHOT_SYMBOL
+        | SOUNDS_SYMBOL
+        | SOURCE_SYMBOL
+        | SQL_AFTER_GTIDS_SYMBOL
+        | SQL_AFTER_MTS_GAPS_SYMBOL
+        | SQL_BEFORE_GTIDS_SYMBOL
+        | SQL_BUFFER_RESULT_SYMBOL
+        | SQL_NO_CACHE_SYMBOL
+        | SQL_THREAD_SYMBOL
+        | SRID_SYMBOL
+        | STACKED_SYMBOL
+        | STARTS_SYMBOL
+        | STATS_AUTO_RECALC_SYMBOL
+        | STATS_PERSISTENT_SYMBOL
+        | STATS_SAMPLE_PAGES_SYMBOL
+        | STATUS_SYMBOL
+        | STORAGE_SYMBOL
+        | STRING_SYMBOL
+        | SUBCLASS_ORIGIN_SYMBOL
+        | SUBDATE_SYMBOL
+        | SUBJECT_SYMBOL
+        | SUBPARTITION_SYMBOL
+        | SUBPARTITIONS_SYMBOL
+        | SUPER_SYMBOL
+        | SUSPEND_SYMBOL
+        | SWAPS_SYMBOL
+        | SWITCHES_SYMBOL
+        | TABLE_NAME_SYMBOL
+        | TABLES_SYMBOL
+        | TABLE_CHECKSUM_SYMBOL
+        | TABLESPACE_SYMBOL
+        | TEMPORARY_SYMBOL
+        | TEMPTABLE_SYMBOL
+        | TEXT_SYMBOL
+        | THAN_SYMBOL
+        | TIES_SYMBOL
+        | TRANSACTION_SYMBOL
+        | TRIGGERS_SYMBOL
+        | TIMESTAMP_SYMBOL
+        | TIMESTAMPADD_SYMBOL
+        | TIMESTAMPDIFF_SYMBOL
+        | TIME_SYMBOL
+        | TYPES_SYMBOL
+        | TYPE_SYMBOL
+        | UDF_RETURNS_SYMBOL
+        | UNBOUNDED_SYMBOL
+        | UNCOMMITTED_SYMBOL
+        | UNDEFINED_SYMBOL
+        | UNDO_BUFFER_SIZE_SYMBOL
+        | UNDOFILE_SYMBOL
+        | UNKNOWN_SYMBOL
+        | UNTIL_SYMBOL
+        | USER_SYMBOL
+        | USE_FRM_SYMBOL
+        | VARIABLES_SYMBOL
+        | VCPU_SYMBOL
+        | VIEW_SYMBOL
+        | VALUE_SYMBOL
+        | WARNINGS_SYMBOL
+        | WAIT_SYMBOL
+        | WEEK_SYMBOL
+        | WORK_SYMBOL
+        | WEIGHT_STRING_SYMBOL
+        | X509_SYMBOL
+        | XID_SYMBOL
+        | XML_SYMBOL
+        | YEAR_SYMBOL
+    )
+    // Tokens that entered or left this rule in specific versions and are not automatically
+    // handled in the lexer.
+    | {serverVersion >= 80014}? ADMIN_SYMBOL
+;

--- a/src/mysql/targets/antlr4-java/build.sh
+++ b/src/mysql/targets/antlr4-java/build.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+
+javac -cp ../../../../antlr/antlr-4.13.1-complete.jar:. ./parsers/*.java
+javac -cp ../../../../antlr/antlr-4.13.1-complete.jar:. ./misc/*.java

--- a/src/mysql/targets/antlr4-java/misc/ParseService.java
+++ b/src/mysql/targets/antlr4-java/misc/ParseService.java
@@ -1,0 +1,13 @@
+package misc;
+
+import org.antlr.v4.runtime.CharStreams;
+import parsers.MySQLLexer;
+
+import java.util.List;
+
+public interface ParseService {
+    void tokenize(String text, int serverVersion, String sqlMode);
+    boolean errorCheck();
+    List<ParserErrorInfo> errorsWithOffset(int offset);
+    void clearDFA();
+}

--- a/src/mysql/targets/antlr4-java/misc/ParseServiceImpl.java
+++ b/src/mysql/targets/antlr4-java/misc/ParseServiceImpl.java
@@ -1,0 +1,105 @@
+package misc;
+
+import org.antlr.v4.runtime.BailErrorStrategy;
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.atn.PredictionMode;
+import parsers.MySQLLexer;
+import parsers.MySQLParser;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+
+public class ParseServiceImpl implements ParseService {
+
+    private final static String[] charSets = {
+        "_big5", "_dec8", "_cp850", "_hp8", "_koi8r", "_latin1", "_latin2", "_swe7", "_ascii", "_ujis",
+        "_sjis", "_hebrew", "_tis620", "_euckr", "_koi8u", "_gb18030", "_gb2312", "_greek", "_cp1250", "_gbk",
+        "_latin5", "_armscii8", "_utf8", "_ucs2", "_cp866", "_keybcs2", "_macce", "_macroman", "_cp852", "_latin7",
+        "_cp1251", "_cp1256", "_cp1257", "_binary", "_geostd8", "_cp932", "_eucjpms", "_utf8mb4", "_utf16", "_utf32"
+    };
+
+    private MySQLLexer lexer;
+    private CommonTokenStream tokenStream;
+    private  MySQLParser parser;
+    private List<ParserErrorInfo> errors = new ArrayList<>();
+    private String sql = "";
+
+    public ParseServiceImpl() {
+        this.lexer = new MySQLLexer(CharStreams.fromString(this.sql));
+        this.tokenStream = new CommonTokenStream(this.lexer);
+        this.parser = new MySQLParser(this.tokenStream);
+
+        SimpleErrorListener errorListener = new SimpleErrorListener(this.errors);
+
+        this.lexer.charSets = new HashSet<>(Arrays.asList(charSets));
+        this.lexer.removeErrorListeners();
+        this.lexer.addErrorListener(errorListener);
+
+        this.parser.removeParseListeners();
+        this.parser.removeErrorListeners();
+        this.parser.addErrorListener(errorListener);
+        this.parser.setErrorHandler(new BailErrorStrategy());
+        this.parser.getInterpreter().setPredictionMode(PredictionMode.SLL);
+        this.parser.setBuildParseTree(false);
+    }
+
+    @Override
+    public void tokenize(String text, int serverVersion, String sqlMode) {
+        this.sql = text.trim();
+
+        // ---------------- without this there are exceptions ------------------
+        this.lexer = new MySQLLexer(CharStreams.fromString(this.sql));
+        this.tokenStream = new CommonTokenStream(this.lexer);
+        // ---------------------------------------------------------------------
+
+        // this.lexer.setInputStream(CharStreams.fromString(this.sql));
+        // this.tokenStream.setTokenSource(this.lexer);
+
+        this.lexer.serverVersion = serverVersion;
+        this.lexer.sqlModeFromString(sqlMode);
+        this.tokenStream.fill();
+    }
+
+    @Override
+    public boolean errorCheck() {
+        this.startParsing();
+        return this.errors.size() == 0;
+    }
+
+    @Override
+    public List<ParserErrorInfo> errorsWithOffset(int offset) {
+        List<ParserErrorInfo> result = new ArrayList<>(this.errors);
+
+        for (ParserErrorInfo error : result) {
+            error.charOffset += offset;
+        }
+
+        return result;
+    }
+
+    @Override
+    public void clearDFA() {
+        this.lexer.getInterpreter().clearDFA();
+        this.parser.getInterpreter().clearDFA();
+    }
+
+    private void startParsing() {
+        try {
+            // ---------------- without this there are exceptions ------------------
+            this.parser = new MySQLParser(this.tokenStream);
+            // ---------------------------------------------------------------------
+
+            this.errors = new ArrayList<>();
+            this.parser.reset();
+            this.parser.serverVersion = this.lexer.serverVersion;
+            this.parser.sqlModes = this.lexer.sqlModes;
+            this.parser.query();
+        }
+        catch (Exception e) {
+            throw new RuntimeException("Failed: `" + this.sql + "`: " + e.getMessage() + " (" + e.getClass().getName() + ")");
+        }
+    }
+}

--- a/src/mysql/targets/antlr4-java/misc/ParserErrorInfo.java
+++ b/src/mysql/targets/antlr4-java/misc/ParserErrorInfo.java
@@ -1,0 +1,20 @@
+package misc;
+
+public class ParserErrorInfo {
+
+    public String message;
+    public int tokenType;
+    public int charOffset;
+    public int line;
+    public int column;
+    public int length;
+
+    public ParserErrorInfo(String message, int tokenType, int charOffset, int line, int column, int length) {
+        this.message = message;
+        this.tokenType = tokenType;
+        this.charOffset = charOffset;
+        this.line = line;
+        this.column = column;
+        this.length = length;
+    }
+}

--- a/src/mysql/targets/antlr4-java/misc/RunBenchmark.java
+++ b/src/mysql/targets/antlr4-java/misc/RunBenchmark.java
@@ -1,0 +1,83 @@
+package misc;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.time.LocalDateTime;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.List;
+import java.util.Scanner;
+
+public class RunBenchmark {
+
+    private static String[] testFiles = {
+        // Large set of all possible query types in different combinations and versions.
+        "../../data/statements.txt",
+
+        // The largest of the example files from the grammar repository:
+        // (https://github.com/antlr/grammars-v4/tree/master/sql/mysql/Positive-Technologies/examples)
+        "../../data/bitrix_queries_cut.sql",
+
+        // Not so many, but some very long insert statements.
+        "../../data/sakila-db/sakila-data.sql",
+    };
+
+    private static void parseFiles(ParseService parseService, boolean clearDFA) throws FileNotFoundException {
+        for (String testFile : testFiles) {
+
+            String contents = new Scanner(new File(testFile)).useDelimiter("\\Z").next();
+            String[] statements = contents.split("\\$\\$\\$");
+
+            if (clearDFA) {
+                // Reset the DFA for each file, to measure the cold state of the parser for each of them (if said so).
+                parseService.clearDFA();
+            }
+
+            long tokenizationTime = 0;
+            long parseTime = 0;
+
+            for (String statement : statements) {
+                long localTimestamp = System.currentTimeMillis();
+                parseService.tokenize(statement, 80400, "ANSI_QUOTES");
+                tokenizationTime += System.currentTimeMillis() - localTimestamp;
+
+                localTimestamp = System.currentTimeMillis();
+                ParserErrorInfo error = null;
+                boolean result = parseService.errorCheck();
+                parseTime += System.currentTimeMillis() - localTimestamp;
+
+                if (!result) {
+                    List<ParserErrorInfo>  errors = parseService.errorsWithOffset(0);
+                    error = errors.size() > 0 ? errors.get(0) : null;
+                }
+
+                if (error != null) {
+                    throw new RuntimeException(
+                            String.format("This query failed to parse:\n%s\nwith error %s, line: %s, column: %s",
+                                    statement, error.message, error.line - 1, error.column));
+                }
+            }
+
+            System.out.println(String.format("%s: %s ms, %s ms", testFile, tokenizationTime, parseTime));
+        }
+    }
+
+    public static void main(String[] args) throws FileNotFoundException {
+
+        final ParseService parseService = new ParseServiceImpl();
+        final String title = "java";
+        final int rounds = 6;
+
+        System.out.println("begin benchmark: " + title);
+
+        parseFiles(parseService, true);
+
+        for (int i = 0; i < rounds - 1; i++) {
+            parseFiles(parseService, false);
+        }
+
+        System.out.println("end benchmark: " + title);
+    }
+}
+
+

--- a/src/mysql/targets/antlr4-java/misc/SimpleErrorListener.java
+++ b/src/mysql/targets/antlr4-java/misc/SimpleErrorListener.java
@@ -1,0 +1,39 @@
+package misc;
+
+import org.antlr.v4.runtime.*;
+import org.antlr.v4.runtime.atn.ATNConfigSet;
+import org.antlr.v4.runtime.dfa.DFA;
+
+import java.util.BitSet;
+import java.util.List;
+
+public class SimpleErrorListener implements ANTLRErrorListener {
+
+    private List<ParserErrorInfo> errors;
+
+    public SimpleErrorListener(List<ParserErrorInfo> errors) {
+        this.errors = errors;
+    }
+
+    @Override
+    public void syntaxError(Recognizer<?, ?> recognizer, Object offendingSymbol, int line, int column, String message, RecognitionException e) {
+        Token token = offendingSymbol instanceof Token ? (Token) offendingSymbol : null;
+        int tokenType = token == null ? 0 : token.getType();
+        int charOffset = token == null ? 0 : token.getStartIndex();
+        int length = token == null ? 0 : token.getStopIndex() - token.getStartIndex() + 1;
+
+        this.errors.add(new ParserErrorInfo(message, tokenType, charOffset, line, column, length));
+    }
+
+    @Override
+    public void reportAmbiguity(Parser parser, DFA dfa, int i, int i1, boolean b, BitSet bitSet, ATNConfigSet atnConfigSet) {
+    }
+
+    @Override
+    public void reportAttemptingFullContext(Parser parser, DFA dfa, int i, int i1, BitSet bitSet, ATNConfigSet atnConfigSet) {
+    }
+
+    @Override
+    public void reportContextSensitivity(Parser parser, DFA dfa, int i, int i1, int i2, ATNConfigSet atnConfigSet) {
+    }
+}

--- a/src/mysql/targets/antlr4-java/parsers/MySQLBaseLexer.java
+++ b/src/mysql/targets/antlr4-java/parsers/MySQLBaseLexer.java
@@ -1,0 +1,254 @@
+package parsers;
+
+import org.antlr.v4.runtime.CharStream;
+import org.antlr.v4.runtime.Lexer;
+import org.antlr.v4.runtime.Token;
+import java.util.*;
+
+public abstract class MySQLBaseLexer extends Lexer {
+
+    public int serverVersion = 0;
+    public Set<SqlMode> sqlModes = new HashSet<>();
+    public Set<String> charSets = new HashSet<>();
+    protected boolean inVersionComment = false;
+
+    protected boolean supportMle = false;
+
+    private Queue<Token> pendingTokens = new ArrayDeque<>();
+    private Map<String, Integer> symbols = new HashMap<>(); // A list of all defined symbols for lookup.
+
+    public MySQLBaseLexer(CharStream input) {
+        super(input);
+    }
+
+    @Override
+    public void reset() {
+        this.inVersionComment = false;
+        super.reset();
+    }
+
+    @Override
+    public Token nextToken() {
+        if (this.pendingTokens.size() > 0) {
+            return this.pendingTokens.poll();
+        }
+        return super.nextToken();
+    }
+
+    public static boolean isRelation(int type) {
+        return switch (type) {
+            case MySQLLexer.EQUAL_OPERATOR, MySQLLexer.ASSIGN_OPERATOR, MySQLLexer.NULL_SAFE_EQUAL_OPERATOR,
+                    MySQLLexer.GREATER_OR_EQUAL_OPERATOR, MySQLLexer.GREATER_THAN_OPERATOR, MySQLLexer.LESS_OR_EQUAL_OPERATOR,
+                    MySQLLexer.LESS_THAN_OPERATOR, MySQLLexer.NOT_EQUAL_OPERATOR, MySQLLexer.NOT_EQUAL2_OPERATOR,
+                    MySQLLexer.PLUS_OPERATOR, MySQLLexer.MINUS_OPERATOR, MySQLLexer.MULT_OPERATOR, MySQLLexer.DIV_OPERATOR,
+                    MySQLLexer.MOD_OPERATOR, MySQLLexer.LOGICAL_NOT_OPERATOR, MySQLLexer.BITWISE_NOT_OPERATOR,
+                    MySQLLexer.SHIFT_LEFT_OPERATOR, MySQLLexer.SHIFT_RIGHT_OPERATOR, MySQLLexer.LOGICAL_AND_OPERATOR,
+                    MySQLLexer.BITWISE_AND_OPERATOR, MySQLLexer.BITWISE_XOR_OPERATOR, MySQLLexer.LOGICAL_OR_OPERATOR,
+                    MySQLLexer.BITWISE_OR_OPERATOR, MySQLLexer.OR_SYMBOL, MySQLLexer.XOR_SYMBOL, MySQLLexer.AND_SYMBOL,
+                    MySQLLexer.IS_SYMBOL, MySQLLexer.BETWEEN_SYMBOL, MySQLLexer.LIKE_SYMBOL, MySQLLexer.REGEXP_SYMBOL,
+                    MySQLLexer.IN_SYMBOL, MySQLLexer.SOUNDS_SYMBOL, MySQLLexer.NOT_SYMBOL -> true;
+            default -> false;
+        };
+    }
+
+    public boolean isNumber(int type) {
+        return switch (type) {
+            case MySQLLexer.INT_NUMBER, MySQLLexer.LONG_NUMBER, MySQLLexer.ULONGLONG_NUMBER, MySQLLexer.FLOAT_NUMBER,
+                    MySQLLexer.HEX_NUMBER, MySQLLexer.BIN_NUMBER, MySQLLexer.DECIMAL_NUMBER -> true;
+            default -> false;
+        };
+    }
+
+    public boolean isDelimiter(int type) {
+        return switch (type) {
+            case MySQLLexer.DOT_SYMBOL, MySQLLexer.COMMA_SYMBOL, MySQLLexer.SEMICOLON_SYMBOL, MySQLLexer.COLON_SYMBOL -> true;
+            default -> false;
+        };
+    }
+
+    public boolean isOperator(int type) {
+        return switch (type) {
+            case MySQLLexer.EQUAL_OPERATOR, MySQLLexer.ASSIGN_OPERATOR, MySQLLexer.NULL_SAFE_EQUAL_OPERATOR,
+                    MySQLLexer.GREATER_OR_EQUAL_OPERATOR, MySQLLexer.GREATER_THAN_OPERATOR, MySQLLexer.LESS_OR_EQUAL_OPERATOR,
+                    MySQLLexer.LESS_THAN_OPERATOR, MySQLLexer.NOT_EQUAL_OPERATOR, MySQLLexer.NOT_EQUAL2_OPERATOR,
+                    MySQLLexer.PLUS_OPERATOR, MySQLLexer.MINUS_OPERATOR, MySQLLexer.MULT_OPERATOR, MySQLLexer.DIV_OPERATOR,
+                    MySQLLexer.MOD_OPERATOR, MySQLLexer.LOGICAL_NOT_OPERATOR, MySQLLexer.BITWISE_NOT_OPERATOR,
+                    MySQLLexer.SHIFT_LEFT_OPERATOR, MySQLLexer.SHIFT_RIGHT_OPERATOR, MySQLLexer.LOGICAL_AND_OPERATOR,
+                    MySQLLexer.BITWISE_AND_OPERATOR, MySQLLexer.BITWISE_XOR_OPERATOR, MySQLLexer.LOGICAL_OR_OPERATOR,
+                    MySQLLexer.BITWISE_OR_OPERATOR, MySQLLexer.OPEN_PAR_SYMBOL, MySQLLexer.CLOSE_PAR_SYMBOL,
+                    MySQLLexer.AT_SIGN_SYMBOL, MySQLLexer.AT_AT_SIGN_SYMBOL, MySQLLexer.PARAM_MARKER, MySQLLexer.ALL_SYMBOL,
+                    MySQLLexer.AND_SYMBOL, MySQLLexer.ANY_SYMBOL, MySQLLexer.BETWEEN_SYMBOL, MySQLLexer.EXISTS_SYMBOL,
+                    MySQLLexer.IN_SYMBOL, MySQLLexer.LIKE_SYMBOL, MySQLLexer.NOT_SYMBOL, MySQLLexer.OR_SYMBOL,
+                    MySQLLexer.EXCEPT_SYMBOL, MySQLLexer.INTERSECT_SYMBOL, MySQLLexer.UNION_SYMBOL, MySQLLexer.CROSS_SYMBOL,
+                    MySQLLexer.FULL_SYMBOL, MySQLLexer.INNER_SYMBOL, MySQLLexer.JOIN_SYMBOL, MySQLLexer.LEFT_SYMBOL,
+                    MySQLLexer.NATURAL_SYMBOL, MySQLLexer.OUTER_SYMBOL, MySQLLexer.RIGHT_SYMBOL, MySQLLexer.STRAIGHT_JOIN_SYMBOL,
+                    MySQLLexer.CONTAINS_SYMBOL, MySQLLexer.IS_SYMBOL, MySQLLexer.NULL_SYMBOL -> true;
+            default -> false;
+        };
+    }
+
+    public boolean isSqlModeActive(SqlMode mode) {
+        return this.sqlModes.contains(mode);
+    }
+
+    public void sqlModeFromString(String modes) {
+        this.sqlModes = new HashSet<>();
+
+        for (String mode : modes.toUpperCase().split(",")) {
+            switch (mode) {
+                case "ANSI", "DB2", "MAXDB", "MSSQL", "ORACLE", "POSTGRESQL" -> {
+                    this.sqlModes.add(SqlMode.AnsiQuotes);
+                    this.sqlModes.add(SqlMode.PipesAsConcat);
+                    this.sqlModes.add(SqlMode.IgnoreSpace);
+                }
+                case "ANSI_QUOTES" -> this.sqlModes.add(SqlMode.AnsiQuotes);
+                case "PIPES_AS_CONCAT" -> this.sqlModes.add(SqlMode.PipesAsConcat);
+                case "NO_BACKSLASH_ESCAPES" -> this.sqlModes.add(SqlMode.NoBackslashEscapes);
+                case "IGNORE_SPACE" -> this.sqlModes.add(SqlMode.IgnoreSpace);
+                case "HIGH_NOT_PRECEDENCE", "MYSQL323", "MYSQL40" -> this.sqlModes.add(SqlMode.HighNotPrecedence);
+                default -> throw new RuntimeException("Unmapped mode: '" + mode + "'");
+            }
+        }
+    }
+
+    protected boolean checkMySQLVersion(String text) {
+        return checkVersion(text);
+    }
+
+    public boolean checkVersion(String text) {
+        if (text.length() < 8) { // Minimum is: /*!12345
+            return false;
+        }
+
+        // Skip version comment introducer.
+        int version = Integer.parseInt(text.substring(3), 10);
+
+        if (version <= this.serverVersion) {
+            this.inVersionComment = true;
+            return true;
+        }
+
+        return false;
+    }
+
+    protected int determineFunction(int proposed) {
+        // Skip any whitespace character if the sql mode says they should be ignored,
+        // before actually trying to match the open parenthesis.
+        char input = (char) this._input.LA(1);
+
+        if (this.isSqlModeActive(SqlMode.IgnoreSpace)) {
+            while (input == ' ' || input == '\t' || input == '\r' || input == '\n') {
+                this.getInterpreter().consume(this._input);
+                this._channel = Lexer.HIDDEN;
+                this._type = MySQLLexer.WHITESPACE;
+                input = (char) this._input.LA(1);
+            }
+        }
+
+        return input == '(' ? proposed : MySQLLexer.IDENTIFIER;
+    }
+
+    protected int determineNumericType(String text) {
+
+        final String longString = "2147483647";
+        final int longLength = 10;
+        final String signedLongString = "-2147483648";
+        final String longLongString = "9223372036854775807";
+        final int longLongLength = 19;
+        final String signedLongLongString = "-9223372036854775808";
+        final int signedLongLongLength = 19;
+        final String unsignedLongLongString = "18446744073709551615";
+        final int unsignedLongLongLength = 20;
+
+        // The original code checks for leading +/- but actually that can never happen, neither in the
+        // server parser (as a digit is used to trigger processing in the lexer) nor in our parser
+        // as our rules are defined without signs. But we do it anyway for maximum compatibility.
+        int length = text.length() - 1;
+        if (length < longLength) { // quick normal case
+            return MySQLLexer.INT_NUMBER;
+        }
+
+        boolean negative = false;
+        int index = 0;
+        if (text.charAt(index) == '+') { // Remove sign and pre-zeros
+            ++index;
+            --length;
+        } else if (text.charAt(index) == '-') {
+            ++index;
+            --length;
+            negative = true;
+        }
+
+        while (text.charAt(index) == '0' && length > 0) {
+            ++index;
+            --length;
+        }
+
+        if (length < longLength) {
+            return MySQLLexer.INT_NUMBER;
+        }
+
+        int smaller;
+        int bigger;
+        String cmp;
+
+        if (negative) {
+            if (length == longLength) {
+                cmp = signedLongString.substring(1);
+                smaller = MySQLLexer.INT_NUMBER; // If <= signed_long_str
+                bigger = MySQLLexer.LONG_NUMBER; // If >= signed_long_str
+            } else if (length < signedLongLongLength) {
+                return MySQLLexer.LONG_NUMBER;
+            } else if (length > signedLongLongLength) {
+                return MySQLLexer.DECIMAL_NUMBER;
+            } else {
+                cmp = signedLongLongString.substring(1);
+                smaller = MySQLLexer.LONG_NUMBER; // If <= signed_longlong_str
+                bigger = MySQLLexer.DECIMAL_NUMBER;
+            }
+        } else {
+            if (length == longLength) {
+                cmp = longString;
+                smaller = MySQLLexer.INT_NUMBER;
+                bigger = MySQLLexer.LONG_NUMBER;
+            } else if (length < longLongLength) {
+                return MySQLLexer.LONG_NUMBER;
+            } else if (length > longLongLength) {
+                if (length > unsignedLongLongLength) {
+                    return MySQLLexer.DECIMAL_NUMBER;
+                }
+                cmp = unsignedLongLongString;
+                smaller = MySQLLexer.ULONGLONG_NUMBER;
+                bigger = MySQLLexer.DECIMAL_NUMBER;
+            } else {
+                cmp = longLongString;
+                smaller = MySQLLexer.LONG_NUMBER;
+                bigger = MySQLLexer.ULONGLONG_NUMBER;
+            }
+        }
+
+        int otherIndex = 0;
+        while (index < text.length() && cmp.charAt(otherIndex++) == text.charAt(index++));
+
+        return text.charAt(index - 1) <= cmp.charAt(otherIndex - 1) ? smaller : bigger;
+    }
+
+    protected int checkCharset(String text) {
+        return this.charSets.contains(text) ? MySQLLexer.UNDERSCORE_CHARSET : MySQLLexer.IDENTIFIER;
+    }
+
+    protected void emitDot() {
+
+        Token dot = this._factory.create(MySQLLexer.DOT_SYMBOL, this.getText());
+        this.pendingTokens.offer(dot);
+
+//        @ts-ignore
+//        this.pendingTokens.push(this._factory.create([this, this._input], MySQLLexer.DOT_SYMBOL,
+//                // @ts-ignore
+//                this.text, this._channel, this._tokenStartCharIndex, this._tokenStartCharIndex, this._tokenStartLine,
+//                this._tokenStartColumn,
+//        ));
+
+        ++this._tokenStartCharIndex;
+    }
+}

--- a/src/mysql/targets/antlr4-java/parsers/MySQLBaseRecognizer.java
+++ b/src/mysql/targets/antlr4-java/parsers/MySQLBaseRecognizer.java
@@ -1,0 +1,28 @@
+package parsers;
+
+import org.antlr.v4.runtime.Parser;
+import org.antlr.v4.runtime.TokenStream;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public abstract class MySQLBaseRecognizer extends Parser {
+
+    // To parameterize the parsing process.
+    public int serverVersion = 0;
+    public Set<SqlMode> sqlModes = new HashSet<>();
+
+    protected boolean supportMle = false;
+
+    public MySQLBaseRecognizer(TokenStream input) {
+        super(input);
+    }
+
+    public boolean isSqlModeActive(SqlMode mode) {
+        return this.sqlModes.contains(mode);
+    }
+
+    public void sqlModeFromString(String _modes) {
+        throw new RuntimeException("sqlModeFromString not implemented");
+    }
+}

--- a/src/mysql/targets/antlr4-java/parsers/SqlMode.java
+++ b/src/mysql/targets/antlr4-java/parsers/SqlMode.java
@@ -1,0 +1,10 @@
+package parsers;
+
+public enum SqlMode {
+    NoMode,
+    AnsiQuotes,
+    HighNotPrecedence,
+    PipesAsConcat,
+    IgnoreSpace,
+    NoBackslashEscapes
+}

--- a/src/mysql/targets/antlr4-java/run.sh
+++ b/src/mysql/targets/antlr4-java/run.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+java -cp ../../../../antlr/antlr-4.13.1-complete.jar:. misc.RunBenchmark


### PR DESCRIPTION
There are still some things going wrong, and during the benchmark, an exception is thrown: `Cannot invoke "org.antlr.v4.runtime.TokenSource.getInputStream()" because the return value of "org.antlr.v4.runtime.Token.getTokenSource()" is null`. Perhaps some of the code  is not ported correctly?

Reproduce it by running:

- `./generate.sh`
- `npm run build-java`
- `npm run run-java-benchmark`